### PR TITLE
Add agent docs and local vendor development setup

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -8,4 +8,16 @@ PYTHON_BIN="$(pyenv which python3 2>/dev/null || command -v python3)"
 export VIRTUAL_ENV="$PWD/.venv"
 export PATH="$VIRTUAL_ENV/bin:$PATH"
 poetry install --only dev
+if [ ! -f .env ]; then
+  if [ -n "${DOC_PAGE_EXTRACTOR_ENV_FILE:-}" ] && [ -f "$DOC_PAGE_EXTRACTOR_ENV_FILE" ]; then
+    cp "$DOC_PAGE_EXTRACTOR_ENV_FILE" .env
+    echo "Copied .env from DOC_PAGE_EXTRACTOR_ENV_FILE."
+  elif [ -f "$HOME/.config/doc-page-extractor/.env" ]; then
+    cp "$HOME/.config/doc-page-extractor/.env" .env
+    echo "Copied .env from ~/.config/doc-page-extractor/.env."
+  else
+    cp .env.template .env
+    echo "Created .env from .env.template. Fill private Vendor settings before running Vendor samples."
+  fi
+fi
 '''

--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,22 @@
+# Local development defaults.
+#
+# Copy this file to .env for machine-specific values. The library does not
+# automatically read this file today; it is a shared convention for agents,
+# local scripts, and future development adapters.
+
+# macos: use an injected development model through create_page_extractor_with_model.
+# cuda: use create_page_extractor with the local Hugging Face model cache.
+DOC_PAGE_EXTRACTOR_MODE=macos
+
+# Where CUDA-capable environments store the Hugging Face DeepSeek-OCR cache.
+DOC_PAGE_EXTRACTOR_MODEL_PATH=./models-cache
+DOC_PAGE_EXTRACTOR_LOCAL_ONLY=false
+
+# Optional remote/OpenAI-compatible OCR backend for macOS development adapters.
+# Leave empty unless you are wiring a custom DeepSeekOCRModel implementation.
+DOC_PAGE_EXTRACTOR_VENDOR_BASE_URL=
+DOC_PAGE_EXTRACTOR_VENDOR_API_KEY=
+DOC_PAGE_EXTRACTOR_VENDOR_MODEL=deepseek-ocr
+
+# Optional path for local fixture responses used by development scripts/tests.
+DOC_PAGE_EXTRACTOR_FIXTURE_RESPONSE=

--- a/.env.template
+++ b/.env.template
@@ -4,19 +4,20 @@
 # automatically read this file today; it is a shared convention for agents,
 # local scripts, and future development adapters.
 
-# macos: use an injected development model through create_page_extractor_with_model.
-# cuda: use create_page_extractor with the local Hugging Face model cache.
-DOC_PAGE_EXTRACTOR_MODE=macos
+# Mutually exclusive backend selector:
+# - fixture: local fixed-response backend; no CUDA and no network.
+# - vendor: OpenAI-compatible remote OCR backend.
+# - local: local Hugging Face DeepSeek-OCR backend; requires CUDA.
+DOC_PAGE_EXTRACTOR_BACKEND=fixture
 
-# Where CUDA-capable environments store the Hugging Face DeepSeek-OCR cache.
-DOC_PAGE_EXTRACTOR_MODEL_PATH=./models-cache
-DOC_PAGE_EXTRACTOR_LOCAL_ONLY=false
+# Fixture backend. Used only when DOC_PAGE_EXTRACTOR_BACKEND=fixture.
+DOC_PAGE_EXTRACTOR_FIXTURE_RESPONSE=
 
-# Optional remote/OpenAI-compatible OCR backend for macOS development adapters.
-# Leave empty unless you are wiring a custom DeepSeekOCRModel implementation.
+# Vendor backend. Used only when DOC_PAGE_EXTRACTOR_BACKEND=vendor.
 DOC_PAGE_EXTRACTOR_VENDOR_BASE_URL=
 DOC_PAGE_EXTRACTOR_VENDOR_API_KEY=
 DOC_PAGE_EXTRACTOR_VENDOR_MODEL=deepseek-ocr
 
-# Optional path for local fixture responses used by development scripts/tests.
-DOC_PAGE_EXTRACTOR_FIXTURE_RESPONSE=
+# Local backend. Used only when DOC_PAGE_EXTRACTOR_BACKEND=local.
+DOC_PAGE_EXTRACTOR_MODEL_PATH=./models-cache
+DOC_PAGE_EXTRACTOR_LOCAL_ONLY=true

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 /plot
 /models-cache
 /.venv
+.env
+.env.local
+.env.*.local
+!.env.template
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Agent Workflow
+
+本项目使用 `~/.agents/skills/vibecoding` 作为通用维护工作法。进入本项目后，先按该 skill 控制任务粒度、模块边界、Git 操作和收尾验证；本文件只补充 `doc-page-extractor` 的项目事实和按条件读取的文档路由。
+
+## Workspace Boundaries
+
+- `doc_page_extractor/` 是发布包源码。`extractor.py` 负责页面抽取流程，`model.py` 负责 Hugging Face/DeepSeek-OCR CUDA 后端，`parser.py`、`redacter.py`、`plot.py` 是可在 macOS 上测试的纯 Python 后处理。
+- `tests/` 存放轻量单元测试，默认不得要求 CUDA、下载模型或访问 Hugging Face。
+- `main.py` 和 `download.py` 是手动验证脚本，会触发真实模型路径；在 macOS 或普通 Agent 任务中不要默认运行。
+- `models-cache/`、`plot/`、`.venv/`、`.env` 是本地状态或生成产物，不要提交。
+- `.env.template` 是可提交的本地配置模板；`.env` 是私有配置，Agent 可以读取但不得把其中密钥写入文档、日志或提交。
+
+## Read Only When Triggered
+
+- 修改抽取流程、数据类型、解析器、涂抹或可视化逻辑时，阅读[架构与模块边界](references/architecture.md)。
+- 设置 macOS 本地环境、运行测试、调 lint、写不依赖 CUDA 的测试或使用 `.env` 时，阅读[macOS 本地开发](references/local-development.md)。
+- 修改 Hugging Face 模型加载、模型下载、`create_page_extractor_with_model`、远程/Vendor/mock 后端或 CUDA 相关行为时，阅读[模型后端](references/model-backends.md)。
+- 修改构建、版本、发布、依赖声明或 PyPI 文档时，阅读[发布流程](docs/RELEASE.md) 和 [macOS 本地开发](references/local-development.md)。
+
+不要一次性读取所有 reference。先根据任务选择最小相关文档，再回到代码确认事实。
+
+## Project Defaults
+
+- macOS 是默认开发环境。不要把“本地不能跑 CUDA 模型”当成阻塞；优先通过 `create_page_extractor_with_model()` 注入开发模型来测试抽取流程。
+- 真实 DeepSeek-OCR 后端需要 CUDA PyTorch、NVIDIA GPU 和模型缓存，只在专门的 GPU 环境验证。
+- 新测试默认应可通过 `poetry run python test.py` 在无 CUDA 环境运行。
+- 不要让普通 import 路径下载模型、加载 torch CUDA 或访问网络。模型下载只能发生在明确的下载/真实模型验证命令中。
+- 文档任务不得修改运行代码，除非用户明确要求或文档链接/配置必须配套调整。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
-# Agent Workflow
+# Agent 工作流
 
-本项目使用 `~/.agents/skills/vibecoding` 作为通用维护工作法。进入本项目后，先按该 skill 控制任务粒度、模块边界、Git 操作和收尾验证；本文件只补充 `doc-page-extractor` 的项目事实和按条件读取的文档路由。
+本文件是 Agent 进入 `doc-page-extractor` 后的项目入口，只记录项目事实、工作区边界和按条件读取的文档路由。
 
-## Workspace Boundaries
+## 工作区边界
 
 - `doc_page_extractor/` 是发布包源码。`extractor.py` 负责页面抽取流程，`model.py` 负责 Hugging Face/DeepSeek-OCR CUDA 后端，`parser.py`、`redacter.py`、`plot.py` 是可在 macOS 上测试的纯 Python 后处理。
 - `tests/` 存放轻量单元测试，默认不得要求 CUDA、下载模型或访问 Hugging Face。
@@ -10,7 +10,7 @@
 - `models-cache/`、`plot/`、`.venv/`、`.env` 是本地状态或生成产物，不要提交。
 - `.env.template` 是可提交的本地配置模板；`.env` 是私有配置，Agent 可以读取但不得把其中密钥写入文档、日志或提交。
 
-## Read Only When Triggered
+## 仅在触发条件满足时读取
 
 - 修改抽取流程、数据类型、解析器、涂抹或可视化逻辑时，阅读[架构与模块边界](references/architecture.md)。
 - 设置 macOS 本地环境、运行测试、调 lint、写不依赖 CUDA 的测试或使用 `.env` 时，阅读[macOS 本地开发](references/local-development.md)。
@@ -19,7 +19,7 @@
 
 不要一次性读取所有 reference。先根据任务选择最小相关文档，再回到代码确认事实。
 
-## Project Defaults
+## 项目默认规则
 
 - macOS 是默认开发环境。不要把“本地不能跑 CUDA 模型”当成阻塞；优先通过 `create_page_extractor_with_model()` 注入开发模型来测试抽取流程。
 - 真实 DeepSeek-OCR 后端需要 CUDA PyTorch、NVIDIA GPU 和模型缓存，只在专门的 GPU 环境验证。

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -27,6 +27,8 @@ cp .env.template .env
 set -a && source .env && set +a
 ```
 
+For VGE/Conductor worktrees, `setup` creates `.env` automatically. It copies `$DOC_PAGE_EXTRACTOR_ENV_FILE` when set, otherwise `~/.config/doc-page-extractor/.env` when present, otherwise `.env.template`.
+
 `DOC_PAGE_EXTRACTOR_BACKEND` is mutually exclusive:
 
 - `fixture`: local fixed-response backend; no CUDA and no network.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -15,6 +15,18 @@ poetry install --only dev
 
 PyTorch and the model runtime dependencies are intentionally not installed for the default development setup. The lightweight test and lint workflow does not need to load the OCR model.
 
+For machine-specific local values, copy the environment template:
+
+```shell
+cp .env.template .env
+```
+
+`.env` is ignored by git. The package does not automatically load it; source it only for scripts or development adapters that need those values:
+
+```shell
+set -a && source .env && set +a
+```
+
 ## Development Workflow
 
 ### Run Tests
@@ -29,6 +41,32 @@ Check code quality with pylint:
 
 ```shell
 poetry run pylint --disable=import-error doc_page_extractor
+```
+
+### macOS Model-Free Development
+
+macOS development should use `create_page_extractor_with_model()` with a fixture or remote backend. Do not call `create_page_extractor().load_models()` unless you are on a CUDA-capable Linux/NVIDIA environment.
+
+```python
+from pathlib import Path
+from doc_page_extractor import create_page_extractor_with_model
+
+
+class FixtureOCRModel:
+    def download(self, revision: str | None) -> None:
+        pass
+
+    def load(self) -> None:
+        pass
+
+    def unload(self) -> None:
+        pass
+
+    def generate(self, prompt, image_path: Path, output_path: Path, size, context, device_number) -> str:
+        return "<|ref|>sample<|/ref|><|det|>[[100, 100, 500, 200]]<|/det|>hello"
+
+
+extractor = create_page_extractor_with_model(FixtureOCRModel())
 ```
 
 ### Build Package
@@ -53,3 +91,7 @@ poetry run pylint --disable=import-error doc_page_extractor
 VGE uses `.conductor/settings.toml` for worktree lifecycle commands:
 
 - `setup` creates or updates the in-project `.venv` with Poetry.
+
+## Agent Documentation
+
+Agents should start with the repository-level `AGENTS.md`. It routes work to focused reference documents under `references/` and keeps CUDA-specific model work separate from macOS-safe development.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -27,6 +27,12 @@ cp .env.template .env
 set -a && source .env && set +a
 ```
 
+`DOC_PAGE_EXTRACTOR_BACKEND` is mutually exclusive:
+
+- `fixture`: local fixed-response backend; no CUDA and no network.
+- `vendor`: OpenAI-compatible remote OCR backend.
+- `local`: local Hugging Face DeepSeek-OCR backend; requires CUDA.
+
 ## Development Workflow
 
 ### Run Tests

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -1,37 +1,37 @@
-# Architecture And Module Boundaries
+# 架构与模块边界
 
-## Runtime Shape
+## 运行时形态
 
-`doc-page-extractor` is a small library that converts a document page image into layout records. A layout record combines a DeepSeek-OCR reference label, a pixel bounding box, and optional text.
+`doc-page-extractor` 是一个小型库，用来把文档页面图片转换为带坐标的布局记录。一个布局记录包含 DeepSeek-OCR 的引用标签、像素坐标框，以及可选文本。
 
-The public package exports lazy symbols from `doc_page_extractor/__init__.py`. Keep imports lazy when possible so lightweight consumers can import the package without immediately loading model code.
+公开包通过 `doc_page_extractor/__init__.py` 延迟导出符号。尽量保持延迟导入，让轻量消费者可以 import 包而不立即加载模型相关代码。
 
-## Source Responsibilities
+## 源码职责
 
-- `types.py` defines public protocols and data structures. Changes here affect downstream libraries.
-- `extractor.py` owns the high-level extraction loop: save a page image, call `DeepSeekOCRModel.generate`, parse the response, yield `Layout` values, and optionally redact already-seen regions for another stage.
-- `model.py` owns the default Hugging Face DeepSeek-OCR backend. This is the CUDA path and should stay isolated from pure parsing/post-processing code.
-- `parser.py` parses `<|ref|>` and `<|det|>` tags and scales normalized coordinates into image pixels.
-- `redacter.py` computes a page-like fill color and redacts regions between extraction stages.
-- `plot.py` draws debug overlays on extracted layouts.
-- `extraction_context.py` provides abort and token-limit bookkeeping for generation.
-- `injection.py` patches the downloaded model object at runtime so the package can add stopping criteria without editing Hugging Face cache files.
+- `types.py` 定义公开协议和数据结构。这里的变更会影响下游库。
+- `extractor.py` 负责高层抽取循环：保存页面图片、调用 `DeepSeekOCRModel.generate`、解析响应、产出 `Layout`，并在多阶段抽取时涂抹已识别区域。
+- `model.py` 负责默认 Hugging Face DeepSeek-OCR 后端。这是 CUDA 路径，应和纯解析/后处理代码保持隔离。
+- `parser.py` 解析 `<|ref|>` 和 `<|det|>` 标签，并把归一化坐标缩放成图片像素坐标。
+- `redacter.py` 计算接近纸张背景的填充色，并在阶段之间涂抹区域。
+- `plot.py` 在抽取结果上绘制调试标注。
+- `extraction_context.py` 提供生成过程中的中断和 token 限制统计。
+- `injection.py` 在运行时 patch 下载得到的模型对象，让本包无需修改 Hugging Face 缓存文件也能注入 stopping criteria。
 
-## Data Flow
+## 数据流
 
-`PageExtractor.extract()` receives a `PIL.Image`, writes a temporary `raw-N.png`, and calls:
+`PageExtractor.extract()` 接收 `PIL.Image`，写入临时 `raw-N.png`，然后调用：
 
 ```python
 model.generate(prompt, image_path, output_path, size, context, device_number)
 ```
 
-The returned string must use DeepSeek-OCR-compatible tags. `parse_ocr_response()` emits ordered `TEXT`, `REF`, and `DET` items. `_PageExtractorImpls._parse_response()` pairs refs and boxes with following text and yields `Layout` values.
+返回字符串必须使用 DeepSeek-OCR 兼容标签。`parse_ocr_response()` 按顺序产出 `TEXT`、`REF` 和 `DET` 项。`_PageExtractorImpls._parse_response()` 把引用、坐标框和后续文本配对，最终产出 `Layout`。
 
-When `stages > 1`, the extractor redacts the top two-thirds of the page plus detected lower text blocks before the next model call. Keep this behavior inside `extractor.py`; model backends should not know about staged redaction.
+当 `stages > 1` 时，抽取器会在下一次模型调用前涂抹页面上方三分之二，以及识别到的下方文字块。这个行为应保留在 `extractor.py` 内；模型后端不应该感知阶段涂抹策略。
 
-## Boundary Rules
+## 边界规则
 
-- Do not add model-provider logic to `parser.py`, `redacter.py`, or `plot.py`.
-- Do not make `types.py` import heavyweight runtime dependencies beyond what is already needed for public type contracts.
-- Preserve `create_page_extractor_with_model()` as the stable test and macOS development seam.
-- Treat protected/private access by downstream projects as compatibility pressure: renaming private fields inside `extractor.py` can still break real users.
+- 不要把模型供应商逻辑加进 `parser.py`、`redacter.py` 或 `plot.py`。
+- 不要让 `types.py` 引入超出公开类型契约所需的重量级运行时依赖。
+- 保持 `create_page_extractor_with_model()` 作为稳定的测试和 macOS 开发接入点。
+- 下游项目可能会访问受保护/私有字段。即使字段名在 Python 层面是私有的，重命名 `extractor.py` 内部字段也可能破坏真实用户。

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -1,0 +1,37 @@
+# Architecture And Module Boundaries
+
+## Runtime Shape
+
+`doc-page-extractor` is a small library that converts a document page image into layout records. A layout record combines a DeepSeek-OCR reference label, a pixel bounding box, and optional text.
+
+The public package exports lazy symbols from `doc_page_extractor/__init__.py`. Keep imports lazy when possible so lightweight consumers can import the package without immediately loading model code.
+
+## Source Responsibilities
+
+- `types.py` defines public protocols and data structures. Changes here affect downstream libraries.
+- `extractor.py` owns the high-level extraction loop: save a page image, call `DeepSeekOCRModel.generate`, parse the response, yield `Layout` values, and optionally redact already-seen regions for another stage.
+- `model.py` owns the default Hugging Face DeepSeek-OCR backend. This is the CUDA path and should stay isolated from pure parsing/post-processing code.
+- `parser.py` parses `<|ref|>` and `<|det|>` tags and scales normalized coordinates into image pixels.
+- `redacter.py` computes a page-like fill color and redacts regions between extraction stages.
+- `plot.py` draws debug overlays on extracted layouts.
+- `extraction_context.py` provides abort and token-limit bookkeeping for generation.
+- `injection.py` patches the downloaded model object at runtime so the package can add stopping criteria without editing Hugging Face cache files.
+
+## Data Flow
+
+`PageExtractor.extract()` receives a `PIL.Image`, writes a temporary `raw-N.png`, and calls:
+
+```python
+model.generate(prompt, image_path, output_path, size, context, device_number)
+```
+
+The returned string must use DeepSeek-OCR-compatible tags. `parse_ocr_response()` emits ordered `TEXT`, `REF`, and `DET` items. `_PageExtractorImpls._parse_response()` pairs refs and boxes with following text and yields `Layout` values.
+
+When `stages > 1`, the extractor redacts the top two-thirds of the page plus detected lower text blocks before the next model call. Keep this behavior inside `extractor.py`; model backends should not know about staged redaction.
+
+## Boundary Rules
+
+- Do not add model-provider logic to `parser.py`, `redacter.py`, or `plot.py`.
+- Do not make `types.py` import heavyweight runtime dependencies beyond what is already needed for public type contracts.
+- Preserve `create_page_extractor_with_model()` as the stable test and macOS development seam.
+- Treat protected/private access by downstream projects as compatibility pressure: renaming private fields inside `extractor.py` can still break real users.

--- a/references/local-development.md
+++ b/references/local-development.md
@@ -1,0 +1,76 @@
+# macOS Local Development
+
+## Default Setup
+
+Use Poetry with an in-project virtual environment:
+
+```shell
+pipx install poetry==2.1.3
+PYTHON_BIN="$(pyenv which python3 2>/dev/null || command -v python3)"
+"$PYTHON_BIN" -m venv .venv
+export VIRTUAL_ENV="$PWD/.venv"
+export PATH="$VIRTUAL_ENV/bin:$PATH"
+poetry install --only dev
+```
+
+This setup intentionally avoids CUDA PyTorch and model downloads. It is enough for parser tests, package import checks, lint, and development-model tests.
+
+## Local Environment File
+
+Copy `.env.template` to `.env` for machine-specific values:
+
+```shell
+cp .env.template .env
+```
+
+`.env` is ignored by git. It may contain private Vendor API settings or local model paths. The library does not automatically load `.env`; source it when a script or manual command needs those values:
+
+```shell
+set -a && source .env && set +a
+```
+
+Keep `.env.template` free of secrets.
+
+## Verification
+
+Default checks for macOS:
+
+```shell
+poetry run python test.py
+poetry run pylint --disable=import-error doc_page_extractor
+```
+
+Do not run `main.py`, `download.py`, or `PageExtractor.load_models()` on macOS unless the task explicitly asks for a real backend experiment.
+
+## Development Backend Pattern
+
+Use `create_page_extractor_with_model()` for local tests that need the full extraction loop without CUDA:
+
+```python
+from pathlib import Path
+
+from doc_page_extractor import create_page_extractor_with_model
+
+
+class FixtureOCRModel:
+    def download(self, revision: str | None) -> None:
+        pass
+
+    def load(self) -> None:
+        pass
+
+    def unload(self) -> None:
+        pass
+
+    def generate(self, prompt, image_path: Path, output_path: Path, size, context, device_number) -> str:
+        return "<|ref|>sample<|/ref|><|det|>[[100, 100, 500, 200]]<|/det|>hello"
+
+
+extractor = create_page_extractor_with_model(FixtureOCRModel())
+```
+
+This exercises image saving, response parsing, layout construction, staged redaction, and context token accounting if the fixture updates `context`.
+
+## What macOS Cannot Prove
+
+macOS checks do not validate CUDA availability, GPU memory behavior, Hugging Face remote code compatibility, `flash_attn`, or multi-GPU device routing. Those require a Linux/NVIDIA environment.

--- a/references/local-development.md
+++ b/references/local-development.md
@@ -31,6 +31,21 @@ set -a && source .env && set +a
 
 `.env.template` 不得包含密钥。
 
+VGE/Conductor 新建 worktree 时，ignored 的 `.env` 不会自动随 git 带过去。`setup` 会按以下顺序创建 `.env`：
+
+1. 如果设置了 `DOC_PAGE_EXTRACTOR_ENV_FILE` 且文件存在，复制它。
+2. 否则如果 `~/.config/doc-page-extractor/.env` 存在，复制它。
+3. 否则复制 `.env.template`，并提示手动填写私有配置。
+
+推荐把长期可复用的私有配置放在：
+
+```shell
+mkdir -p ~/.config/doc-page-extractor
+cp .env ~/.config/doc-page-extractor/.env
+```
+
+该私有文件不属于仓库，不应提交或写入文档。
+
 ## 后端选择
 
 `.env` 通过 `DOC_PAGE_EXTRACTOR_BACKEND` 表达互斥的 OCR 后端选择：

--- a/references/local-development.md
+++ b/references/local-development.md
@@ -31,6 +31,16 @@ set -a && source .env && set +a
 
 `.env.template` 不得包含密钥。
 
+## 后端选择
+
+`.env` 通过 `DOC_PAGE_EXTRACTOR_BACKEND` 表达互斥的 OCR 后端选择：
+
+- `fixture`：默认 macOS 开发后端，使用固定响应或 fixture 文件，不加载 CUDA，也不访问网络。
+- `vendor`：OpenAI-compatible 远程 OCR 后端，适合在 macOS 上对接真实 OCR 能力。
+- `local`：本地 Hugging Face DeepSeek-OCR 后端，需要 CUDA 环境。
+
+即使 `.env` 中同时保留了 fixture、vendor 和 local 的字段，也只有当前 `DOC_PAGE_EXTRACTOR_BACKEND` 对应的一组字段应被脚本或开发适配器读取。
+
 ## 验证命令
 
 macOS 默认检查：

--- a/references/local-development.md
+++ b/references/local-development.md
@@ -1,8 +1,8 @@
-# macOS Local Development
+# macOS 本地开发
 
-## Default Setup
+## 默认环境
 
-Use Poetry with an in-project virtual environment:
+使用 Poetry 和项目内虚拟环境：
 
 ```shell
 pipx install poetry==2.1.3
@@ -13,38 +13,38 @@ export PATH="$VIRTUAL_ENV/bin:$PATH"
 poetry install --only dev
 ```
 
-This setup intentionally avoids CUDA PyTorch and model downloads. It is enough for parser tests, package import checks, lint, and development-model tests.
+这个环境刻意避开 CUDA PyTorch 和模型下载。它足够用于解析器测试、包导入检查、lint，以及使用开发模型的测试。
 
-## Local Environment File
+## 本地环境文件
 
-Copy `.env.template` to `.env` for machine-specific values:
+把 `.env.template` 复制为 `.env`，填写本机私有配置：
 
 ```shell
 cp .env.template .env
 ```
 
-`.env` is ignored by git. It may contain private Vendor API settings or local model paths. The library does not automatically load `.env`; source it when a script or manual command needs those values:
+`.env` 会被 git 忽略。它可以包含私有 Vendor API 配置或本地模型路径。本库当前不会自动读取 `.env`；只有脚本或手动命令需要这些值时才 source：
 
 ```shell
 set -a && source .env && set +a
 ```
 
-Keep `.env.template` free of secrets.
+`.env.template` 不得包含密钥。
 
-## Verification
+## 验证命令
 
-Default checks for macOS:
+macOS 默认检查：
 
 ```shell
 poetry run python test.py
 poetry run pylint --disable=import-error doc_page_extractor
 ```
 
-Do not run `main.py`, `download.py`, or `PageExtractor.load_models()` on macOS unless the task explicitly asks for a real backend experiment.
+除非任务明确要求真实后端实验，否则不要在 macOS 上运行 `main.py`、`download.py` 或 `PageExtractor.load_models()`。
 
-## Development Backend Pattern
+## 开发后端模式
 
-Use `create_page_extractor_with_model()` for local tests that need the full extraction loop without CUDA:
+需要在无 CUDA 环境测试完整抽取循环时，使用 `create_page_extractor_with_model()`：
 
 ```python
 from pathlib import Path
@@ -69,8 +69,8 @@ class FixtureOCRModel:
 extractor = create_page_extractor_with_model(FixtureOCRModel())
 ```
 
-This exercises image saving, response parsing, layout construction, staged redaction, and context token accounting if the fixture updates `context`.
+这会覆盖图片保存、响应解析、布局构造、阶段涂抹；如果 fixture 更新了 `context`，也能覆盖 token 统计。
 
-## What macOS Cannot Prove
+## macOS 不能验证的内容
 
-macOS checks do not validate CUDA availability, GPU memory behavior, Hugging Face remote code compatibility, `flash_attn`, or multi-GPU device routing. Those require a Linux/NVIDIA environment.
+macOS 检查不能验证 CUDA 可用性、显存行为、Hugging Face remote code 兼容性、`flash_attn` 或多 GPU 设备路由。这些需要 Linux/NVIDIA 环境。

--- a/references/model-backends.md
+++ b/references/model-backends.md
@@ -19,6 +19,14 @@ generate(prompt, image_path, output_path, size, context, device_number) -> str
 
 对 fixture 或远程后端来说，`download()`、`load()` 和 `unload()` 可以是空实现。`generate()` 必须返回包含 `<|ref|>` 和 `<|det|>` 标签的 DeepSeek-OCR 兼容文本，这样现有解析器才能产出 `Layout`。
 
+本地 `.env` 约定用 `DOC_PAGE_EXTRACTOR_BACKEND` 做互斥选择：
+
+- `fixture` 使用固定 OCR 响应或 fixture 文件。
+- `vendor` 使用 OpenAI-compatible 远程 OCR 后端。
+- `local` 使用 `create_page_extractor()` 和本地 Hugging Face 模型缓存。
+
+这只是当前脚本和后续开发适配器的约定；库代码本身不会自动读取 `.env`。
+
 实现远程后端时：
 
 - 上传或编码 `extractor.py` 生成的 `image_path`。

--- a/references/model-backends.md
+++ b/references/model-backends.md
@@ -1,0 +1,39 @@
+# Model Backends
+
+## Default Backend
+
+`create_page_extractor()` constructs `DeepSeekOCRHugginfaceModel`. This backend downloads and loads `deepseek-ai/DeepSeek-OCR` through Hugging Face and requires CUDA at runtime.
+
+The model cache path is optional in API terms, but production deployments should provide one. With `local_only=True`, `model_path` is required and must contain the Hugging Face cache structure for DeepSeek-OCR.
+
+## Development And Remote Backends
+
+`create_page_extractor_with_model(model)` is the supported way to replace local CUDA inference. The injected object must implement the `DeepSeekOCRModel` protocol:
+
+```python
+download(revision)
+load()
+unload()
+generate(prompt, image_path, output_path, size, context, device_number) -> str
+```
+
+`download()`, `load()`, and `unload()` may be no-ops for fixture or remote backends. `generate()` must return DeepSeek-OCR-compatible text using `<|ref|>` and `<|det|>` tags so the existing parser can produce `Layout` values.
+
+When implementing a remote backend:
+
+- Upload or encode the `image_path` produced by `extractor.py`.
+- Send the exact `prompt` argument unless the task intentionally changes prompting.
+- Return only the OCR response text expected by the parser.
+- If usage metadata is available, update `context.input_tokens` and `context.output_tokens`.
+- Convert provider token/billing failures into `TokenLimitError` when that is the closest semantic match.
+
+## CUDA Path Rules
+
+- `model.py` is the only module that should import torch for CUDA model loading.
+- `check_env()` warning behavior is not a complete runtime guard; `_ensure_models()` is where no-CUDA becomes a hard failure.
+- Avoid model downloads during ordinary imports, tests, lint, or package build.
+- `download.py` and `main.py` are manual scripts for real-backend work. They should not become required for macOS development.
+
+## Compatibility Notes
+
+Downstream projects may rely on `create_page_extractor_with_model()` to keep their own process CPU-only. Treat that function and the `DeepSeekOCRModel.generate()` signature as public compatibility surface.

--- a/references/model-backends.md
+++ b/references/model-backends.md
@@ -1,14 +1,14 @@
-# Model Backends
+# 模型后端
 
-## Default Backend
+## 默认后端
 
-`create_page_extractor()` constructs `DeepSeekOCRHugginfaceModel`. This backend downloads and loads `deepseek-ai/DeepSeek-OCR` through Hugging Face and requires CUDA at runtime.
+`create_page_extractor()` 会创建 `DeepSeekOCRHugginfaceModel`。这个后端通过 Hugging Face 下载并加载 `deepseek-ai/DeepSeek-OCR`，运行时需要 CUDA。
 
-The model cache path is optional in API terms, but production deployments should provide one. With `local_only=True`, `model_path` is required and must contain the Hugging Face cache structure for DeepSeek-OCR.
+从 API 角度看，模型缓存路径是可选的；生产部署应显式提供。使用 `local_only=True` 时，必须提供 `model_path`，且其中需要包含 DeepSeek-OCR 的 Hugging Face 缓存结构。
 
-## Development And Remote Backends
+## 开发后端与远程后端
 
-`create_page_extractor_with_model(model)` is the supported way to replace local CUDA inference. The injected object must implement the `DeepSeekOCRModel` protocol:
+`create_page_extractor_with_model(model)` 是替换本地 CUDA 推理的受支持方式。注入对象必须实现 `DeepSeekOCRModel` 协议：
 
 ```python
 download(revision)
@@ -17,23 +17,23 @@ unload()
 generate(prompt, image_path, output_path, size, context, device_number) -> str
 ```
 
-`download()`, `load()`, and `unload()` may be no-ops for fixture or remote backends. `generate()` must return DeepSeek-OCR-compatible text using `<|ref|>` and `<|det|>` tags so the existing parser can produce `Layout` values.
+对 fixture 或远程后端来说，`download()`、`load()` 和 `unload()` 可以是空实现。`generate()` 必须返回包含 `<|ref|>` 和 `<|det|>` 标签的 DeepSeek-OCR 兼容文本，这样现有解析器才能产出 `Layout`。
 
-When implementing a remote backend:
+实现远程后端时：
 
-- Upload or encode the `image_path` produced by `extractor.py`.
-- Send the exact `prompt` argument unless the task intentionally changes prompting.
-- Return only the OCR response text expected by the parser.
-- If usage metadata is available, update `context.input_tokens` and `context.output_tokens`.
-- Convert provider token/billing failures into `TokenLimitError` when that is the closest semantic match.
+- 上传或编码 `extractor.py` 生成的 `image_path`。
+- 除非任务明确要改 prompt，否则传递原始 `prompt` 参数。
+- 只返回解析器期望的 OCR 响应文本。
+- 如果供应商返回 usage 信息，更新 `context.input_tokens` 和 `context.output_tokens`。
+- 当供应商的 token/计费失败语义接近 token 限制时，转换为 `TokenLimitError`。
 
-## CUDA Path Rules
+## CUDA 路径规则
 
-- `model.py` is the only module that should import torch for CUDA model loading.
-- `check_env()` warning behavior is not a complete runtime guard; `_ensure_models()` is where no-CUDA becomes a hard failure.
-- Avoid model downloads during ordinary imports, tests, lint, or package build.
-- `download.py` and `main.py` are manual scripts for real-backend work. They should not become required for macOS development.
+- `model.py` 是唯一应该为了 CUDA 模型加载而 import torch 的模块。
+- `check_env()` 的 warning 不是完整运行时保护；无 CUDA 的硬失败发生在 `_ensure_models()`。
+- 普通 import、测试、lint 或包构建过程中不得下载模型。
+- `download.py` 和 `main.py` 是真实后端手动脚本，不应成为 macOS 开发的必要步骤。
 
-## Compatibility Notes
+## 兼容性说明
 
-Downstream projects may rely on `create_page_extractor_with_model()` to keep their own process CPU-only. Treat that function and the `DeepSeekOCRModel.generate()` signature as public compatibility surface.
+下游项目可能依赖 `create_page_extractor_with_model()` 来保持自身进程 CPU-only。应把这个函数和 `DeepSeekOCRModel.generate()` 的签名视作公开兼容面。


### PR DESCRIPTION
## Summary
- Add agent-facing project guidance and focused references for architecture, macOS development, and model backends.
- Document the mutually exclusive local backend selector: fixture, vendor, and local.
- Bootstrap ignored .env files in Conductor worktree setup from DOC_PAGE_EXTRACTOR_ENV_FILE, ~/.config/doc-page-extractor/.env, or .env.template.

## Verification
- python -c "import tomllib; tomllib.load(open('.conductor/settings.toml','rb')); print('toml ok')"
- poetry run python test.py
- poetry run pylint --disable=import-error doc_page_extractor

## Security
- No .env or API key is committed.
- Private Vendor settings remain in ignored local files only.