### PR TITLE
chore: simplify Conductor env setup

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -9,15 +9,7 @@ export VIRTUAL_ENV="$PWD/.venv"
 export PATH="$VIRTUAL_ENV/bin:$PATH"
 poetry install --only dev
 if [ ! -f .env ]; then
-  if [ -n "${DOC_PAGE_EXTRACTOR_ENV_FILE:-}" ] && [ -f "$DOC_PAGE_EXTRACTOR_ENV_FILE" ]; then
-    cp "$DOC_PAGE_EXTRACTOR_ENV_FILE" .env
-    echo "Copied .env from DOC_PAGE_EXTRACTOR_ENV_FILE."
-  elif [ -f "$HOME/.config/doc-page-extractor/.env" ]; then
-    cp "$HOME/.config/doc-page-extractor/.env" .env
-    echo "Copied .env from ~/.config/doc-page-extractor/.env."
-  else
-    cp .env.template .env
-    echo "Created .env from .env.template. Fill private Vendor settings before running Vendor samples."
-  fi
+  cp .env.template .env
+  echo "Created .env from .env.template. Fill private OCR settings before running remote samples."
 fi
 '''

--- a/references/local-development.md
+++ b/references/local-development.md
@@ -33,18 +33,10 @@ set -a && source .env && set +a
 
 VGE/Conductor 新建 worktree 时，ignored 的 `.env` 不会自动随 git 带过去。`setup` 会按以下顺序创建 `.env`：
 
-1. 如果设置了 `DOC_PAGE_EXTRACTOR_ENV_FILE` 且文件存在，复制它。
-2. 否则如果 `~/.config/doc-page-extractor/.env` 存在，复制它。
-3. 否则复制 `.env.template`，并提示手动填写私有配置。
+1. 如果 worktree 里已经有 `.env`，保留它。
+2. 否则复制 `.env.template`，并提示手动填写私有配置。
 
-推荐把长期可复用的私有配置放在：
-
-```shell
-mkdir -p ~/.config/doc-page-extractor
-cp .env ~/.config/doc-page-extractor/.env
-```
-
-该私有文件不属于仓库，不应提交或写入文档。
+Conductor 不会从仓库外的隐藏路径复制私有配置。需要真实远程 OCR 凭据时，应在对应 worktree 的 `.env` 中明确填写；`.env` 不属于仓库，不应提交或写入文档。
 
 ## 后端选择
 


### PR DESCRIPTION
## Summary
- simplify Conductor setup so worktrees only create .env from .env.template when missing
- remove DOC_PAGE_EXTRACTOR_ENV_FILE and ~/.config/doc-page-extractor/.env fallback documentation
- clarify that private OCR credentials must be written explicitly into the worktree .env

## Verification
- poetry run python test.py
- poetry run pylint --disable=import-error doc_page_extractor