### PR TITLE
docs: prepare 1.1.0 adapter release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,97 +1,132 @@
 # doc-page-extractor
 
-Document page extraction tool powered by DeepSeek-OCR.
+Document page extraction tool that converts page images into text layouts with pixel coordinates.
+
+The default backend remains local DeepSeek-OCR for existing users. Version 1.1 also adds a unified OCR adapter layer with DeepSeek OpenAI-compatible Vendor support and Baidu cloud OCR support.
 
 ## Installation
-
-> **⚠️ Important:** This package requires PyTorch with CUDA support (GPU Required). PyTorch is NOT automatically installed - you must install it manually first.
-
-### Step 1: Install PyTorch with CUDA
-
-Choose the command that matches your CUDA version:
-
-```bash
-# For CUDA 12.1 (recommended for most users)
-pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121
-
-# For CUDA 11.8
-pip install torch torchvision --index-url https://download.pytorch.org/whl/cu118
-
-# For CUDA 12.6
-pip install torch torchvision --index-url https://download.pytorch.org/whl/cu126
-```
-
-> 💡 **Don't know your CUDA version?** Run `nvidia-smi` to check, or just try CUDA 12.1 (works with most recent drivers).
-
-### Step 2: Install doc-page-extractor
 
 ```bash
 pip install doc-page-extractor
 ```
 
-### Verify Installation
+PyTorch is not installed automatically. You only need CUDA PyTorch when using the local DeepSeek-OCR backend.
 
-Check if everything is working:
+## Backends
 
-```bash
-python -c "import doc_page_extractor; import torch; print('✓ Installation successful!'); print('✓ CUDA available:', torch.cuda.is_available())"
-```
+### Local DeepSeek-OCR
 
-Expected output:
-```
-✓ Installation successful!
-✓ CUDA available: True
-```
-
-If CUDA shows `False`, see the troubleshooting section below.
-
-## Usage
+This is the default and keeps the existing API behavior:
 
 ```python
-from doc_page_extractor import PageExtractor
+from doc_page_extractor import create_page_extractor
 
-# Your code here
+extractor = create_page_extractor()
 ```
 
-## Troubleshooting
+Install CUDA PyTorch before using this backend:
 
-### "PyTorch is required but not installed!"
-
-Install PyTorch first:
 ```bash
+# CUDA 12.1
 pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121
+
+# CUDA 11.8
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cu118
+
+# CUDA 12.6
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cu126
 ```
 
-### "CUDA is not available!"
+Check CUDA with:
 
-**Check your GPU driver:**
 ```bash
 nvidia-smi
+python -c "import torch; print(torch.cuda.is_available())"
 ```
 
-**If the command fails**, you need to install NVIDIA drivers:
-- Download from: https://www.nvidia.com/download/index.aspx
+### DeepSeek OCR Vendor
 
-**If it succeeds**, you might have CPU-only PyTorch. Reinstall with CUDA:
-```bash
-pip uninstall torch torchvision
-pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121
+Use this backend when DeepSeek OCR is exposed through an OpenAI-compatible endpoint:
+
+```python
+from doc_page_extractor import (
+    DeepSeekVendorOCRConfig,
+    create_deepseek_vendor_page_extractor,
+)
+
+extractor = create_deepseek_vendor_page_extractor(
+    DeepSeekVendorOCRConfig.from_env()
+)
+```
+
+Expected environment variables:
+
+```dotenv
+DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_BASE_URL=
+DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_API_KEY=
+DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_MODEL=deepseek-ocr
+DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_TEMPERATURE=0.0
+DOC_PAGE_EXTRACTOR_DEEPSEEK_VENDOR_TOP_P=0.7
+```
+
+### Baidu Cloud OCR
+
+Use this backend for Baidu Unlimited-OCR through Baidu Cloud:
+
+```python
+from doc_page_extractor import BaiduCloudOCRConfig, create_baidu_page_extractor
+
+extractor = create_baidu_page_extractor(BaiduCloudOCRConfig.from_env())
+```
+
+Expected environment variables:
+
+```dotenv
+DOC_PAGE_EXTRACTOR_BAIDU_AK=
+DOC_PAGE_EXTRACTOR_BAIDU_SK=
+DOC_PAGE_EXTRACTOR_BAIDU_BASE_URL=https://aip.baidubce.com
+```
+
+## Extraction
+
+All backends return the same `PageExtractor` shape:
+
+```python
+from PIL import Image
+from doc_page_extractor import ExtractionContext
+
+context = ExtractionContext(check_aborted=lambda: False)
+
+for page_image, layouts in extractor.extract(
+    image=Image.open("page.png"),
+    size="gundam",
+    stages=1,
+    context=context,
+):
+    for layout in layouts:
+        print(layout.det, layout.text)
+```
+
+`Layout` keeps the original `ref`, `det`, and `text` fields. Version 1.1 adds optional metadata fields such as `type`, `polygon`, `html`, `source`, and `raw` for adapters that provide richer layout data.
+
+## Development
+
+For contributors and developers, see [Development Guide](docs/DEVELOPMENT.md).
+
+Useful local commands:
+
+```shell
+poetry run python test.py
+poetry run pylint --disable=import-error doc_page_extractor
+poetry run python scripts/ocr_sample.py --adapter both --image tests/images/friendly-title.png
 ```
 
 ## Requirements
 
 - Python >= 3.10, < 3.14
-- **NVIDIA GPU with CUDA 11.8 or 12.1 support (Required)**
-- Sufficient GPU memory (recommended: 4GB+ VRAM)
+- CUDA-capable NVIDIA GPU only when using local DeepSeek-OCR
+- Remote OCR credentials only when using DeepSeek Vendor or Baidu Cloud OCR
 
 ## Dependencies & Licenses
 
-This project is licensed under the MIT License. It depends on the DeepSeek-OCR model which uses **easydict** (LGPLv3) for configuration management.
-
-## Development
-
-For contributors and developers, see [Development Guide](docs/DEVELOPMENT.md) for:
-- Running tests
-- Running lint checks
-- Building the package
-
+This project is licensed under the MIT License. The local DeepSeek-OCR backend depends on the DeepSeek-OCR model, which uses **easydict** (LGPLv3) for configuration management.

--- a/doc_page_extractor/__init__.py
+++ b/doc_page_extractor/__init__.py
@@ -1,6 +1,6 @@
 # pylint: disable=undefined-all-variable
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 _LAZY_EXPORTS = {
     "AbortError": ("extraction_context", "AbortError"),

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -53,7 +53,23 @@ poetry run pylint --disable=import-error doc_page_extractor
 
 ### macOS Model-Free Development
 
-macOS development should use `create_page_extractor_with_model()` with a fixture or remote backend. Do not call `create_page_extractor().load_models()` unless you are on a CUDA-capable Linux/NVIDIA environment.
+macOS development should use `create_page_extractor_with_adapter()` for new backend work, or `create_page_extractor_with_model()` when testing the legacy DeepSeek model protocol. Do not call `create_page_extractor().load_models()` unless you are on a CUDA-capable Linux/NVIDIA environment.
+
+New adapter code should implement the unified OCR adapter protocol and return layout results directly:
+
+```python
+from doc_page_extractor import (
+    BaiduCloudOCRConfig,
+    DeepSeekVendorOCRConfig,
+    create_baidu_page_extractor,
+    create_deepseek_vendor_page_extractor,
+)
+
+deepseek = create_deepseek_vendor_page_extractor(DeepSeekVendorOCRConfig.from_env())
+baidu = create_baidu_page_extractor(BaiduCloudOCRConfig.from_env())
+```
+
+The legacy model protocol remains available for small fixtures:
 
 ```python
 from pathlib import Path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "doc-page-extractor"
-version = "1.0.12"
-description = "Document page extraction tool powered by DeepSeek-OCR"
+version = "1.1.0"
+description = "Document page extraction tool with DeepSeek-OCR and Baidu OCR adapters"
 authors = [
     {name = "Tao Zeyu", email = "i@taozeyu.com"}
 ]

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -2,16 +2,17 @@
 
 ## 运行时形态
 
-`doc-page-extractor` 是一个小型库，用来把文档页面图片转换为带坐标的布局记录。一个布局记录包含 DeepSeek-OCR 的引用标签、像素坐标框，以及可选文本。
+`doc-page-extractor` 是一个小型库，用来把文档页面图片转换为带坐标的布局记录。一个布局记录包含引用类型、像素坐标框、可选文本，以及后端提供的可选元数据。
 
 公开包通过 `doc_page_extractor/__init__.py` 延迟导出符号。尽量保持延迟导入，让轻量消费者可以 import 包而不立即加载模型相关代码。
 
 ## 源码职责
 
 - `types.py` 定义公开协议和数据结构。这里的变更会影响下游库。
-- `extractor.py` 负责高层抽取循环：保存页面图片、调用 `DeepSeekOCRModel.generate`、解析响应、产出 `Layout`，并在多阶段抽取时涂抹已识别区域。
-- `model.py` 负责默认 Hugging Face DeepSeek-OCR 后端。这是 CUDA 路径，应和纯解析/后处理代码保持隔离。
-- `parser.py` 解析 `<|ref|>` 和 `<|det|>` 标签，并把归一化坐标缩放成图片像素坐标。
+- `extractor.py` 负责高层抽取循环：保存页面图片、调用 `OCRAdapter.extract_page`、产出 `Layout`，并在多阶段抽取时涂抹已识别区域。
+- `adapters/` 存放后端适配器。DeepSeek 本地 CUDA、DeepSeek OpenAI-compatible Vendor、百度云 OCR 都应在这里转换成统一布局。
+- `model.py` 负责 Hugging Face DeepSeek-OCR 本地 CUDA 实现。这是 DeepSeek local adapter 的实现细节，应和纯解析/后处理代码保持隔离。
+- `parser.py` 解析 DeepSeek `<|ref|>` 和 `<|det|>` 标签，并把归一化坐标缩放成图片像素坐标。它不负责解析百度云 JSON。
 - `redacter.py` 计算接近纸张背景的填充色，并在阶段之间涂抹区域。
 - `plot.py` 在抽取结果上绘制调试标注。
 - `extraction_context.py` 提供生成过程中的中断和 token 限制统计。
@@ -22,10 +23,10 @@
 `PageExtractor.extract()` 接收 `PIL.Image`，写入临时 `raw-N.png`，然后调用：
 
 ```python
-model.generate(prompt, image_path, output_path, size, context, device_number)
+adapter.extract_page(prompt, image_path, output_path, size, context, device_number)
 ```
 
-返回字符串必须使用 DeepSeek-OCR 兼容标签。`parse_ocr_response()` 按顺序产出 `TEXT`、`REF` 和 `DET` 项。`_PageExtractorImpls._parse_response()` 把引用、坐标框和后续文本配对，最终产出 `Layout`。
+adapter 返回 `OCRPageResult`，其中包含统一的 `Layout` 列表。DeepSeek adapter 可以先得到 DeepSeek-OCR 兼容标签字符串，再用 `parse_ocr_response()` 转换成布局；百度云 adapter 则直接把 `parse_result_url` JSON 映射成布局。
 
 当 `stages > 1` 时，抽取器会在下一次模型调用前涂抹页面上方三分之二，以及识别到的下方文字块。这个行为应保留在 `extractor.py` 内；模型后端不应该感知阶段涂抹策略。
 
@@ -33,5 +34,5 @@ model.generate(prompt, image_path, output_path, size, context, device_number)
 
 - 不要把模型供应商逻辑加进 `parser.py`、`redacter.py` 或 `plot.py`。
 - 不要让 `types.py` 引入超出公开类型契约所需的重量级运行时依赖。
-- 保持 `create_page_extractor_with_model()` 作为稳定的测试和 macOS 开发接入点。
+- 保持 `create_page_extractor_with_model()` 作为稳定的兼容入口；新后端优先实现 `OCRAdapter`。
 - 下游项目可能会访问受保护/私有字段。即使字段名在 Python 层面是私有的，重命名 `extractor.py` 内部字段也可能破坏真实用户。

--- a/references/local-development.md
+++ b/references/local-development.md
@@ -71,7 +71,21 @@ poetry run python scripts/ocr_sample.py --adapter both --image tests/images/frie
 
 ## 开发后端模式
 
-需要在无 CUDA 环境测试完整抽取循环时，使用 `create_page_extractor_with_model()`：
+需要在无 CUDA 环境测试完整抽取循环时，新后端优先实现 `OCRAdapter`，并通过 `create_page_extractor_with_adapter()` 或专用工厂函数接入。DeepSeek Vendor 和百度云可直接使用：
+
+```python
+from doc_page_extractor import (
+    BaiduCloudOCRConfig,
+    DeepSeekVendorOCRConfig,
+    create_baidu_page_extractor,
+    create_deepseek_vendor_page_extractor,
+)
+
+deepseek = create_deepseek_vendor_page_extractor(DeepSeekVendorOCRConfig.from_env())
+baidu = create_baidu_page_extractor(BaiduCloudOCRConfig.from_env())
+```
+
+兼容旧 DeepSeek 模型协议或编写极小 fixture 时，也可以使用 `create_page_extractor_with_model()`：
 
 ```python
 from pathlib import Path


### PR DESCRIPTION
## Summary
- bump package metadata and runtime __version__ to 1.1.0
- refresh README around the unified adapter layer, DeepSeek local/vendor, and Baidu Cloud OCR
- update development and agent-facing docs to match the adapter architecture

## Verification
- poetry run python test.py
- poetry run pylint --disable=import-error doc_page_extractor
- poetry run python - <<'PY'
import doc_page_extractor
print(doc_page_extractor.__version__)
from doc_page_extractor import BaiduCloudOCRConfig, DeepSeekVendorOCRConfig, create_baidu_page_extractor, create_deepseek_vendor_page_extractor
print('exports-ok')
PY