### PR TITLE
Add structured OCR layout API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Document page extraction tool that converts page images into text layouts with pixel coordinates.
 
-The default backend remains local DeepSeek-OCR for existing users. Version 1.1 also adds a unified OCR adapter layer with DeepSeek OpenAI-compatible Vendor support and Baidu cloud OCR support.
+The default backend remains local DeepSeek-OCR for existing users. Version 1.1 adds a unified OCR adapter layer with DeepSeek OpenAI-compatible Vendor support and Baidu cloud OCR support.
 
 ## Installation
 
@@ -107,7 +107,27 @@ for page_image, layouts in extractor.extract(
         print(layout.det, layout.text)
 ```
 
-`Layout` keeps the original `ref`, `det`, and `text` fields. Version 1.1 adds optional metadata fields such as `type`, `polygon`, `html`, `source`, and `raw` for adapters that provide richer layout data.
+`Layout` keeps the original `ref`, `det`, and `text` fields. Version 1.1.1 also adds `kind`, a stable `LayoutKind` enum that callers should prefer over provider-specific labels. Adapter metadata remains available through optional fields such as `type`, `polygon`, `html`, `source`, and `raw`.
+
+Use `extract_page_results()` when you need the structured page model:
+
+```python
+from doc_page_extractor import LayoutKind
+
+for page_image, result in extractor.extract_page_results(
+    image=Image.open("page.png"),
+    size="gundam",
+    stages=1,
+    context=context,
+):
+    for block in result.structured.blocks:
+        if block.kind == LayoutKind.TABLE:
+            print(block.html)
+```
+
+The structured model groups asset captions with images, tables, and equations when possible. DeepSeek output is structured from flat OCR tags; Baidu Cloud OCR is normalized from Baidu's richer layout JSON into the same public kinds.
+
+Baidu Cloud OCR extracts footnotes directly. If `stages > 1` is requested with the Baidu adapter, the extractor emits a warning and runs a single stage because DeepSeek-style multi-stage redaction can erase Baidu footnote regions.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ for page_image, result in extractor.extract_page_results(
     stages=1,
     context=context,
 ):
+    if result.structured is None:
+        continue
     for block in result.structured.blocks:
         if block.kind == LayoutKind.TABLE:
             print(block.html)

--- a/doc_page_extractor/__init__.py
+++ b/doc_page_extractor/__init__.py
@@ -1,6 +1,6 @@
 # pylint: disable=undefined-all-variable
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 _LAZY_EXPORTS = {
     "AbortError": ("extraction_context", "AbortError"),
@@ -15,9 +15,12 @@ _LAZY_EXPORTS = {
     "ExtractionAbortedError": ("extraction_context", "ExtractionAbortedError"),
     "ExtractionContext": ("types", "ExtractionContext"),
     "Layout": ("types", "Layout"),
+    "LayoutKind": ("types", "LayoutKind"),
     "OCRAdapter": ("types", "OCRAdapter"),
     "OCRPageResult": ("types", "OCRPageResult"),
+    "PageBlock": ("types", "PageBlock"),
     "PageExtractor": ("types", "PageExtractor"),
+    "StructuredPage": ("types", "StructuredPage"),
     "TokenLimitError": ("extraction_context", "TokenLimitError"),
     "create_baidu_page_extractor": ("extractor", "create_baidu_page_extractor"),
     "create_page_extractor": ("extractor", "create_page_extractor"),
@@ -50,6 +53,9 @@ __all__ = [
     "ExtractionAbortedError",
     "TokenLimitError",
     "Layout",
+    "LayoutKind",
+    "PageBlock",
+    "StructuredPage",
 ]
 
 

--- a/doc_page_extractor/adapters/baidu.py
+++ b/doc_page_extractor/adapters/baidu.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
+from ..structure import baidu_type_to_kind, build_structured_page, legacy_ref_for_kind
 from ..types import DeepSeekOCRSize, ExtractionContext, Layout, OCRPageResult
 
 if TYPE_CHECKING:
@@ -58,6 +59,8 @@ class BaiduCloudOCRConfig:
 
 
 class BaiduCloudOCRAdapter:
+    supports_multi_stage = False
+
     def __init__(self, config: BaiduCloudOCRConfig) -> None:
         self._config = config
         self._access_token: str | None = None
@@ -84,6 +87,7 @@ class BaiduCloudOCRAdapter:
         return OCRPageResult(
             layouts=layouts,
             source="baidu",
+            structured=build_structured_page(layouts),
             raw={
                 "task_id": task_id,
                 "status": task_result.get("status"),
@@ -221,11 +225,13 @@ def parse_baidu_layouts(parse_result: dict[str, Any]) -> list[Layout]:
             text = _optional_str(item.get("text"))
             table_html = _optional_str(item.get("table_html"))
             html = table_html or (text if layout_type == "table" else None)
+            kind = baidu_type_to_kind(layout_type, text)
             layouts.append(
                 Layout(
-                    ref=layout_type or "baidu",
+                    ref=legacy_ref_for_kind(kind, layout_type or "baidu"),
                     det=det,
                     text=text,
+                    kind=kind,
                     type=layout_type,
                     polygon=_parse_polygon(item.get("polygon")),
                     html=html,

--- a/doc_page_extractor/adapters/deepseek.py
+++ b/doc_page_extractor/adapters/deepseek.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator, Iterable, Protocol, cast
 
 from ..parser import ParsedItemKind, parse_ocr_response
+from ..structure import build_structured_page, deepseek_ref_to_kind
 from ..types import (
     DeepSeekOCRModel,
     DeepSeekOCRSize,
@@ -29,12 +30,20 @@ def parse_deepseek_layouts(
     image: _ImageLike, response: str, source: str = "deepseek"
 ) -> list[Layout]:
     return [
-        Layout(ref=ref, det=det, text=text, source=source)
+        Layout(
+            ref=ref,
+            det=det,
+            text=text,
+            kind=deepseek_ref_to_kind(ref),
+            source=source,
+        )
         for ref, det, text in _parse_deepseek_response(image, response)
     ]
 
 
 class DeepSeekModelOCRAdapter:
+    supports_multi_stage = True
+
     def __init__(self, model: DeepSeekOCRModel, source: str = "deepseek") -> None:
         self._model = model
         self._source = source
@@ -69,6 +78,7 @@ class DeepSeekModelOCRAdapter:
         return OCRPageResult(
             layouts=layouts,
             source=self._source,
+            structured=build_structured_page(layouts),
             raw_text=response,
         )
 
@@ -140,6 +150,8 @@ class DeepSeekVendorOCRConfig:
 
 
 class DeepSeekVendorOCRAdapter:
+    supports_multi_stage = True
+
     def __init__(self, config: DeepSeekVendorOCRConfig) -> None:
         self._config = config
 
@@ -211,6 +223,7 @@ class DeepSeekVendorOCRAdapter:
         return OCRPageResult(
             layouts=layouts,
             source="deepseek-vendor",
+            structured=build_structured_page(layouts),
             raw_text=raw_text,
             raw={"usage": usage},
         )

--- a/doc_page_extractor/adapters/deepseek.py
+++ b/doc_page_extractor/adapters/deepseek.py
@@ -38,6 +38,7 @@ def parse_deepseek_layouts(
             source=source,
         )
         for ref, det, text in _parse_deepseek_response(image, response)
+        if _has_area(det)
     ]
 
 
@@ -252,6 +253,10 @@ def _parse_deepseek_response(
             ref = cast(str, content)
     if det is not None and ref is not None:
         yield ref, det, None
+
+
+def _has_area(det: tuple[int, int, int, int]) -> bool:
+    return det[2] > det[0] and det[3] > det[1]
 
 
 def _data_url(image_path: Path) -> str:

--- a/doc_page_extractor/extractor.py
+++ b/doc_page_extractor/extractor.py
@@ -1,5 +1,6 @@
 import sys
 import tempfile
+import warnings
 from os import PathLike
 from pathlib import Path
 from typing import Generator, Iterable
@@ -20,6 +21,7 @@ from .types import (
     ExtractionContext,
     Layout,
     OCRAdapter,
+    OCRPageResult,
     PageExtractor,
 )
 
@@ -84,7 +86,32 @@ class _PageExtractorImpls:
         context: ExtractionContext | None = None,
         device_number: int | None = None,
     ) -> Generator[tuple[Image.Image, list[Layout]], None, None]:
+        for stage_image, page_result in self.extract_page_results(
+            image=image,
+            size=size,
+            stages=stages,
+            context=context,
+            device_number=device_number,
+        ):
+            yield stage_image, page_result.layouts
+
+    def extract_page_results(
+        self,
+        image: Image.Image,
+        size: DeepSeekOCRSize,
+        stages: int = 1,
+        context: ExtractionContext | None = None,
+        device_number: int | None = None,
+    ) -> Generator[tuple[Image.Image, OCRPageResult], None, None]:
         assert stages >= 1, "stages must be at least 1"
+        if stages > 1 and not getattr(self._adapter, "supports_multi_stage", True):
+            warnings.warn(
+                "This OCR adapter does not support multi-stage redaction; "
+                "using a single extraction stage.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            stages = 1
 
         fill_color: tuple[int, int, int] | None = None
         output_path: Path | None = None
@@ -113,7 +140,7 @@ class _PageExtractorImpls:
                     image_path.unlink(missing_ok=True)
 
                 layouts = page_result.layouts
-                yield image, layouts
+                yield image, page_result
 
                 if i < stages - 1:
                     if fill_color is None:

--- a/doc_page_extractor/extractor.py
+++ b/doc_page_extractor/extractor.py
@@ -21,6 +21,7 @@ from .types import (
     OCRPageResult,
     PageExtractor,
 )
+from .structure import build_structured_page
 
 if TYPE_CHECKING:
     from PIL import Image
@@ -49,6 +50,8 @@ def create_page_extractor_with_model(model: DeepSeekOCRModel) -> PageExtractor:
 
 
 def create_page_extractor_with_adapter(adapter: OCRAdapter) -> PageExtractor:
+    if not hasattr(adapter, "supports_multi_stage"):
+        setattr(adapter, "supports_multi_stage", True)
     if not isinstance(adapter, OCRAdapter):
         raise TypeError("adapter must implement OCRAdapter protocol")
     return _PageExtractorImpls(adapter)
@@ -140,6 +143,8 @@ class _PageExtractorImpls:
                     image_path.unlink(missing_ok=True)
 
                 layouts = page_result.layouts
+                if page_result.structured is None:
+                    page_result.structured = build_structured_page(layouts)
                 yield image, page_result
 
                 if i < stages - 1:
@@ -150,7 +155,7 @@ class _PageExtractorImpls:
                     image = redact(
                         image=image.copy(),
                         fill_color=fill_color,
-                        rectangles=self._redect_rectangles(
+                        rectangles=self._redact_rectangles(
                             image=image,
                             dets=(layout.det for layout in layouts),
                         ),
@@ -159,7 +164,7 @@ class _PageExtractorImpls:
             if temp_dir is not None:
                 temp_dir.cleanup()
 
-    def _redect_rectangles(
+    def _redact_rectangles(
         self, image: "Image.Image", dets: Iterable[tuple[int, int, int, int]]
     ):
         # 将页面上 2/3 全部涂抹，并沿着 2/3 线向下涂抹到每一个识别为文字区块的底部

--- a/doc_page_extractor/extractor.py
+++ b/doc_page_extractor/extractor.py
@@ -12,7 +12,6 @@ from .adapters.deepseek import (
     DeepSeekVendorOCRAdapter,
     DeepSeekVendorOCRConfig,
 )
-from .redacter import background_color, redact
 from .types import (
     DeepSeekOCRModel,
     DeepSeekOCRSize,
@@ -144,6 +143,8 @@ class _PageExtractorImpls:
                 yield image, page_result
 
                 if i < stages - 1:
+                    from .redacter import background_color, redact
+
                     if fill_color is None:
                         fill_color = background_color(image)
                     image = redact(

--- a/doc_page_extractor/extractor.py
+++ b/doc_page_extractor/extractor.py
@@ -3,9 +3,7 @@ import tempfile
 import warnings
 from os import PathLike
 from pathlib import Path
-from typing import Generator, Iterable
-
-from PIL import Image
+from typing import TYPE_CHECKING, Generator, Iterable
 
 from .adapters.baidu import BaiduCloudOCRAdapter, BaiduCloudOCRConfig
 from .adapters.deepseek import (
@@ -24,6 +22,9 @@ from .types import (
     OCRPageResult,
     PageExtractor,
 )
+
+if TYPE_CHECKING:
+    from PIL import Image
 
 _DEFAULT_PROMPT = "<image>\n<|grounding|>Convert the document to markdown."
 
@@ -80,12 +81,12 @@ class _PageExtractorImpls:
 
     def extract(
         self,
-        image: Image.Image,
+        image: "Image.Image",
         size: DeepSeekOCRSize,
         stages: int = 1,
         context: ExtractionContext | None = None,
         device_number: int | None = None,
-    ) -> Generator[tuple[Image.Image, list[Layout]], None, None]:
+    ) -> Generator[tuple["Image.Image", list[Layout]], None, None]:
         for stage_image, page_result in self.extract_page_results(
             image=image,
             size=size,
@@ -97,12 +98,12 @@ class _PageExtractorImpls:
 
     def extract_page_results(
         self,
-        image: Image.Image,
+        image: "Image.Image",
         size: DeepSeekOCRSize,
         stages: int = 1,
         context: ExtractionContext | None = None,
         device_number: int | None = None,
-    ) -> Generator[tuple[Image.Image, OCRPageResult], None, None]:
+    ) -> Generator[tuple["Image.Image", OCRPageResult], None, None]:
         assert stages >= 1, "stages must be at least 1"
         if stages > 1 and not getattr(self._adapter, "supports_multi_stage", True):
             warnings.warn(
@@ -158,7 +159,7 @@ class _PageExtractorImpls:
                 temp_dir.cleanup()
 
     def _redect_rectangles(
-        self, image: Image.Image, dets: Iterable[tuple[int, int, int, int]]
+        self, image: "Image.Image", dets: Iterable[tuple[int, int, int, int]]
     ):
         # 将页面上 2/3 全部涂抹，并沿着 2/3 线向下涂抹到每一个识别为文字区块的底部
         # 这种方法旨在涂抹掉尽可能多的不是页脚的区域，以排除诸如页眉之类干扰识别页脚的内容

--- a/doc_page_extractor/structure.py
+++ b/doc_page_extractor/structure.py
@@ -1,0 +1,154 @@
+import re
+from collections.abc import Iterable
+
+from .types import Layout, LayoutKind, PageBlock, StructuredPage
+
+_ASSET_KINDS = {
+    LayoutKind.IMAGE,
+    LayoutKind.TABLE,
+    LayoutKind.EQUATION,
+}
+
+_CAPTION_TO_ASSET = {
+    LayoutKind.IMAGE_CAPTION: LayoutKind.IMAGE,
+    LayoutKind.TABLE_CAPTION: LayoutKind.TABLE,
+    LayoutKind.EQUATION_CAPTION: LayoutKind.EQUATION,
+}
+
+_IGNORED_KINDS = {
+    LayoutKind.HEADER,
+    LayoutKind.FOOTER,
+    LayoutKind.PAGE_NUMBER,
+    LayoutKind.ASIDE,
+}
+
+_TABLE_CAPTION_PATTERNS = (
+    re.compile(r"^\s*第[一二三四五六七八九十百千万零〇\d]+表\b"),
+    re.compile(r"^\s*表\s*[一二三四五六七八九十百千万零〇\d]+\b"),
+    re.compile(r"^\s*table\s+\d+\b", re.IGNORECASE),
+)
+
+
+def deepseek_ref_to_kind(ref: str | None) -> LayoutKind:
+    normalized = (ref or "").strip()
+    if normalized in {"text", "正文"}:
+        return LayoutKind.TEXT
+    if normalized in {"title", "sub_title"}:
+        return LayoutKind.TITLE
+    if normalized in {"image", "figure"}:
+        return LayoutKind.IMAGE
+    if normalized in {"image_caption", "figure_caption"}:
+        return LayoutKind.IMAGE_CAPTION
+    if normalized in {"table"}:
+        return LayoutKind.TABLE
+    if normalized in {"table_caption"}:
+        return LayoutKind.TABLE_CAPTION
+    if normalized in {"equation", "formula"}:
+        return LayoutKind.EQUATION
+    if normalized in {"equation_caption", "formula_caption"}:
+        return LayoutKind.EQUATION_CAPTION
+    if normalized in {"footnote"}:
+        return LayoutKind.FOOTNOTE
+    return LayoutKind.UNKNOWN
+
+
+def baidu_type_to_kind(layout_type: str | None, text: str | None = None) -> LayoutKind:
+    normalized = (layout_type or "").strip()
+    if normalized == "text":
+        if _looks_like_table_caption(text):
+            return LayoutKind.TABLE_CAPTION
+        return LayoutKind.TEXT
+    if normalized == "paragraph_title":
+        return LayoutKind.TITLE
+    if normalized == "formula":
+        return LayoutKind.EQUATION
+    if normalized == "image":
+        return LayoutKind.IMAGE
+    if normalized == "figure_title":
+        return LayoutKind.IMAGE_CAPTION
+    if normalized == "table":
+        return LayoutKind.TABLE
+    if normalized == "footnote":
+        return LayoutKind.FOOTNOTE
+    if normalized == "header":
+        return LayoutKind.HEADER
+    if normalized == "footer":
+        return LayoutKind.FOOTER
+    if normalized == "number":
+        return LayoutKind.PAGE_NUMBER
+    if normalized == "aside_text":
+        return LayoutKind.ASIDE
+    return LayoutKind.UNKNOWN
+
+
+def legacy_ref_for_kind(kind: LayoutKind, fallback: str | None = None) -> str:
+    if kind == LayoutKind.TITLE:
+        return "sub_title"
+    if kind == LayoutKind.FOOTNOTE:
+        return "text"
+    if kind == LayoutKind.PAGE_NUMBER:
+        return "text"
+    if kind in _IGNORED_KINDS:
+        return "text"
+    if kind == LayoutKind.UNKNOWN:
+        return fallback or "unknown"
+    return kind.value
+
+
+def build_structured_page(layouts: Iterable[Layout]) -> StructuredPage:
+    blocks: list[PageBlock] = []
+    ignored: list[Layout] = []
+    pending_asset: PageBlock | None = None
+    pending_captions: dict[LayoutKind, list[PageBlock]] = {}
+
+    for layout in layouts:
+        kind = layout.kind
+        if kind in _IGNORED_KINDS:
+            ignored.append(layout)
+            continue
+
+        if kind in _ASSET_KINDS:
+            pending_asset = _block_from_layout(layout)
+            attached_captions = pending_captions.pop(kind, [])
+            pending_asset.children.extend(attached_captions)
+            for caption in attached_captions:
+                pending_asset.layouts.extend(caption.layouts)
+            blocks.append(pending_asset)
+            continue
+
+        if kind in _CAPTION_TO_ASSET:
+            caption_block = _block_from_layout(layout)
+            asset_kind = _CAPTION_TO_ASSET[kind]
+            if pending_asset and pending_asset.kind == asset_kind:
+                pending_asset.children.append(caption_block)
+                pending_asset.layouts.append(layout)
+            else:
+                pending_captions.setdefault(asset_kind, []).append(caption_block)
+            continue
+
+        pending_asset = None
+        for captions in pending_captions.values():
+            blocks.extend(captions)
+        pending_captions = {}
+        blocks.append(_block_from_layout(layout))
+
+    for captions in pending_captions.values():
+        blocks.extend(captions)
+
+    return StructuredPage(blocks=blocks, ignored=ignored)
+
+
+def _block_from_layout(layout: Layout) -> PageBlock:
+    return PageBlock(
+        kind=layout.kind,
+        det=layout.det,
+        text=layout.text,
+        html=layout.html,
+        layouts=[layout],
+    )
+
+
+def _looks_like_table_caption(text: str | None) -> bool:
+    if not text:
+        return False
+    return any(pattern.search(text) for pattern in _TABLE_CAPTION_PATTERNS)

--- a/doc_page_extractor/structure.py
+++ b/doc_page_extractor/structure.py
@@ -23,8 +23,8 @@ _IGNORED_KINDS = {
 }
 
 _TABLE_CAPTION_PATTERNS = (
-    re.compile(r"^\s*第[一二三四五六七八九十百千万零〇\d]+表\b"),
-    re.compile(r"^\s*表\s*[一二三四五六七八九十百千万零〇\d]+\b"),
+    re.compile(r"^\s*第\s*[一二三四五六七八九十百千万零〇\d\s]+\s*表\b"),
+    re.compile(r"^\s*表\s*[一二三四五六七八九十百千万零〇\d\s]+\b"),
     re.compile(r"^\s*table\s+\d+\b", re.IGNORECASE),
 )
 
@@ -108,6 +108,9 @@ def build_structured_page(layouts: Iterable[Layout]) -> StructuredPage:
             continue
 
         if kind in _ASSET_KINDS:
+            if _is_noise_asset(layout):
+                ignored.append(layout)
+                continue
             pending_asset = _block_from_layout(layout)
             attached_captions = pending_captions.pop(kind, [])
             pending_asset.children.extend(attached_captions)
@@ -152,3 +155,10 @@ def _looks_like_table_caption(text: str | None) -> bool:
     if not text:
         return False
     return any(pattern.search(text) for pattern in _TABLE_CAPTION_PATTERNS)
+
+
+def _is_noise_asset(layout: Layout) -> bool:
+    x1, y1, x2, y2 = layout.det
+    area = max(0, x2 - x1) * max(0, y2 - y1)
+    has_content = bool((layout.text or "").strip() or (layout.html or "").strip())
+    return layout.kind in _ASSET_KINDS and area < 5000 and not has_content

--- a/doc_page_extractor/structure.py
+++ b/doc_page_extractor/structure.py
@@ -29,7 +29,6 @@ _TABLE_CAPTION_PATTERNS = (
 )
 
 _FOOTNOTE_MARK_PATTERN = re.compile(r"^\s*[①②③④⑤⑥⑦⑧⑨⑩]\s*\S+")
-_SIDE_NUMBER_PATTERN = re.compile(r"^\s*\d+\s*$")
 
 
 def deepseek_ref_to_kind(ref: str | None) -> LayoutKind:
@@ -101,26 +100,18 @@ def legacy_ref_for_kind(kind: LayoutKind, fallback: str | None = None) -> str:
 
 
 def build_structured_page(layouts: Iterable[Layout]) -> StructuredPage:
-    layout_list = list(layouts)
-    body_left = _body_left(layout_list)
     blocks: list[PageBlock] = []
     ignored: list[Layout] = []
     pending_asset: PageBlock | None = None
     pending_captions: dict[LayoutKind, list[PageBlock]] = {}
 
-    for layout in layout_list:
+    for layout in layouts:
         kind = layout.kind
         if kind in _IGNORED_KINDS:
             ignored.append(layout)
             continue
-        if _is_side_number(layout, body_left):
-            ignored.append(layout)
-            continue
 
         if kind in _ASSET_KINDS:
-            if _is_noise_asset(layout):
-                ignored.append(layout)
-                continue
             pending_asset = _block_from_layout(layout)
             attached_captions = pending_captions.pop(kind, [])
             pending_asset.children.extend(attached_captions)
@@ -165,33 +156,3 @@ def _looks_like_table_caption(text: str | None) -> bool:
     if not text:
         return False
     return any(pattern.search(text) for pattern in _TABLE_CAPTION_PATTERNS)
-
-
-def _is_noise_asset(layout: Layout) -> bool:
-    x1, y1, x2, y2 = layout.det
-    area = max(0, x2 - x1) * max(0, y2 - y1)
-    has_content = bool((layout.text or "").strip() or (layout.html or "").strip())
-    return layout.kind in _ASSET_KINDS and area < 5000 and not has_content
-
-
-def _body_left(layouts: Iterable[Layout]) -> int | None:
-    candidates: list[int] = []
-    for layout in layouts:
-        if layout.kind not in {LayoutKind.TEXT, LayoutKind.TITLE}:
-            continue
-        x1, y1, x2, y2 = layout.det
-        area = max(0, x2 - x1) * max(0, y2 - y1)
-        if area > 20000:
-            candidates.append(x1)
-    return min(candidates) if candidates else None
-
-
-def _is_side_number(layout: Layout, body_left: int | None) -> bool:
-    if body_left is None or layout.kind != LayoutKind.TEXT:
-        return False
-    if not _SIDE_NUMBER_PATTERN.search(layout.text or ""):
-        return False
-    x1, y1, x2, y2 = layout.det
-    width = max(0, x2 - x1)
-    height = max(0, y2 - y1)
-    return width <= 100 and height <= 100 and x2 < body_left - 20

--- a/doc_page_extractor/structure.py
+++ b/doc_page_extractor/structure.py
@@ -28,6 +28,9 @@ _TABLE_CAPTION_PATTERNS = (
     re.compile(r"^\s*table\s+\d+\b", re.IGNORECASE),
 )
 
+_FOOTNOTE_MARK_PATTERN = re.compile(r"^\s*[①②③④⑤⑥⑦⑧⑨⑩]\s*\S+")
+_SIDE_NUMBER_PATTERN = re.compile(r"^\s*\d+\s*$")
+
 
 def deepseek_ref_to_kind(ref: str | None) -> LayoutKind:
     normalized = (ref or "").strip()
@@ -75,6 +78,8 @@ def baidu_type_to_kind(layout_type: str | None, text: str | None = None) -> Layo
     if normalized == "footer":
         return LayoutKind.FOOTER
     if normalized == "number":
+        if _FOOTNOTE_MARK_PATTERN.search(text or ""):
+            return LayoutKind.FOOTNOTE
         return LayoutKind.PAGE_NUMBER
     if normalized == "aside_text":
         return LayoutKind.ASIDE
@@ -96,14 +101,19 @@ def legacy_ref_for_kind(kind: LayoutKind, fallback: str | None = None) -> str:
 
 
 def build_structured_page(layouts: Iterable[Layout]) -> StructuredPage:
+    layout_list = list(layouts)
+    body_left = _body_left(layout_list)
     blocks: list[PageBlock] = []
     ignored: list[Layout] = []
     pending_asset: PageBlock | None = None
     pending_captions: dict[LayoutKind, list[PageBlock]] = {}
 
-    for layout in layouts:
+    for layout in layout_list:
         kind = layout.kind
         if kind in _IGNORED_KINDS:
+            ignored.append(layout)
+            continue
+        if _is_side_number(layout, body_left):
             ignored.append(layout)
             continue
 
@@ -162,3 +172,26 @@ def _is_noise_asset(layout: Layout) -> bool:
     area = max(0, x2 - x1) * max(0, y2 - y1)
     has_content = bool((layout.text or "").strip() or (layout.html or "").strip())
     return layout.kind in _ASSET_KINDS and area < 5000 and not has_content
+
+
+def _body_left(layouts: Iterable[Layout]) -> int | None:
+    candidates: list[int] = []
+    for layout in layouts:
+        if layout.kind not in {LayoutKind.TEXT, LayoutKind.TITLE}:
+            continue
+        x1, y1, x2, y2 = layout.det
+        area = max(0, x2 - x1) * max(0, y2 - y1)
+        if area > 20000:
+            candidates.append(x1)
+    return min(candidates) if candidates else None
+
+
+def _is_side_number(layout: Layout, body_left: int | None) -> bool:
+    if body_left is None or layout.kind != LayoutKind.TEXT:
+        return False
+    if not _SIDE_NUMBER_PATTERN.search(layout.text or ""):
+        return False
+    x1, y1, x2, y2 = layout.det
+    width = max(0, x2 - x1)
+    height = max(0, y2 - y1)
+    return width <= 100 and height <= 100 and x2 < body_left - 20

--- a/doc_page_extractor/types.py
+++ b/doc_page_extractor/types.py
@@ -107,6 +107,8 @@ class PageExtractor(Protocol):
 
 @runtime_checkable
 class OCRAdapter(Protocol):
+    supports_multi_stage: bool
+
     def extract_page(
         self,
         prompt: str,

--- a/doc_page_extractor/types.py
+++ b/doc_page_extractor/types.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from enum import Enum
 from os import PathLike
 from pathlib import Path
 from typing import Any, TYPE_CHECKING, runtime_checkable, Protocol, Generator, Literal, Callable
@@ -8,6 +9,23 @@ if TYPE_CHECKING:
 
 
 DeepSeekOCRSize = Literal["tiny", "small", "base", "large", "gundam"]
+
+
+class LayoutKind(str, Enum):
+    TEXT = "text"
+    TITLE = "title"
+    IMAGE = "image"
+    IMAGE_CAPTION = "image_caption"
+    TABLE = "table"
+    TABLE_CAPTION = "table_caption"
+    EQUATION = "equation"
+    EQUATION_CAPTION = "equation_caption"
+    FOOTNOTE = "footnote"
+    HEADER = "header"
+    FOOTER = "footer"
+    PAGE_NUMBER = "page_number"
+    ASIDE = "aside"
+    UNKNOWN = "unknown"
 
 
 @dataclass
@@ -20,6 +38,23 @@ class Layout:
     html: str | None = None
     source: str | None = None
     raw: dict[str, Any] | None = field(default=None, repr=False)
+    kind: LayoutKind = LayoutKind.UNKNOWN
+
+
+@dataclass
+class PageBlock:
+    kind: LayoutKind
+    det: tuple[int, int, int, int]
+    text: str | None = None
+    html: str | None = None
+    layouts: list[Layout] = field(default_factory=list)
+    children: list["PageBlock"] = field(default_factory=list)
+
+
+@dataclass
+class StructuredPage:
+    blocks: list[PageBlock]
+    ignored: list[Layout] = field(default_factory=list)
 
 
 @dataclass
@@ -28,6 +63,7 @@ class OCRPageResult:
     source: str
     raw_text: str | None = None
     raw: dict[str, Any] | None = field(default=None, repr=False)
+    structured: StructuredPage | None = None
 
 
 @dataclass
@@ -56,6 +92,16 @@ class PageExtractor(Protocol):
         context: ExtractionContext | None = None,
         device_number: int | None = None,
     ) -> Generator[tuple["Image.Image", list[Layout]], None, None]:
+        ...
+
+    def extract_page_results(
+        self,
+        image: "Image.Image",
+        size: DeepSeekOCRSize,
+        stages: int = 1,
+        context: ExtractionContext | None = None,
+        device_number: int | None = None,
+    ) -> Generator[tuple["Image.Image", OCRPageResult], None, None]:
         ...
 
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -69,6 +69,16 @@ deepseek = create_deepseek_vendor_page_extractor(DeepSeekVendorOCRConfig.from_en
 baidu = create_baidu_page_extractor(BaiduCloudOCRConfig.from_env())
 ```
 
+### Layout Contract
+
+New code should prefer `Layout.kind` for stable layout semantics. `Layout.ref`
+is kept for backward compatibility with the original DeepSeek-style API, while
+`Layout.type` and `Layout.raw` preserve provider-specific data and should not be
+treated as stable cross-provider contracts.
+
+Use `extract_page_results()` when you need `OCRPageResult.structured`; keep using
+`extract()` when the legacy flat `list[Layout]` result is enough.
+
 The legacy model protocol remains available for small fixtures:
 
 ```python
@@ -103,7 +113,7 @@ poetry run python scripts/ocr_sample.py --adapter baidu --image tests/images/fri
 poetry run python scripts/ocr_sample.py --adapter both --image tests/images/friendly-title.png
 ```
 
-The sample reads `tests/images/friendly-title.png`, runs the configured DeepSeek Vendor backend, the Baidu cloud backend, or both, and prints layout summaries, text previews, and elapsed time. Use `--image path/to/image.png` to try another image.
+The sample reads `tests/images/friendly-title.png`, runs the configured DeepSeek Vendor backend, the Baidu cloud backend, or both, and prints layout summaries, including `ref`, `kind`, provider `type`, text previews, and elapsed time. Use `--image path/to/image.png` to try another image.
 
 ### Build Package
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "doc-page-extractor"
-version = "1.1.0"
+version = "1.1.1"
 description = "Document page extraction tool with DeepSeek-OCR and Baidu OCR adapters"
 authors = [
     {name = "Tao Zeyu", email = "i@taozeyu.com"}

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -2,15 +2,16 @@
 
 ## 运行时形态
 
-`doc-page-extractor` 是一个小型库，用来把文档页面图片转换为带坐标的布局记录。一个布局记录包含引用类型、像素坐标框、可选文本，以及后端提供的可选元数据。
+`doc-page-extractor` 是一个小型库，用来把文档页面图片转换为带坐标的布局记录。一个布局记录包含稳定的 `LayoutKind`、兼容旧接口的 `ref`、像素坐标框、可选文本，以及后端提供的可选元数据。
 
 公开包通过 `doc_page_extractor/__init__.py` 延迟导出符号。尽量保持延迟导入，让轻量消费者可以 import 包而不立即加载模型相关代码。
 
 ## 源码职责
 
-- `types.py` 定义公开协议和数据结构。这里的变更会影响下游库。
+- `types.py` 定义公开协议和数据结构。这里的变更会影响下游库。`Layout.ref` 是兼容字段，新增代码应优先使用 `Layout.kind`。
 - `extractor.py` 负责高层抽取循环：保存页面图片、调用 `OCRAdapter.extract_page`、产出 `Layout`，并在多阶段抽取时涂抹已识别区域。
 - `adapters/` 存放后端适配器。DeepSeek 本地 CUDA、DeepSeek OpenAI-compatible Vendor、百度云 OCR 都应在这里转换成统一布局。
+- `structure.py` 负责把 DeepSeek/Baidu 的标签坍缩成稳定枚举，并构造 `StructuredPage`。这里可以吸收下游项目中通用的图、表格、公式与 caption 关联逻辑。
 - `model.py` 负责 Hugging Face DeepSeek-OCR 本地 CUDA 实现。这是 DeepSeek local adapter 的实现细节，应和纯解析/后处理代码保持隔离。
 - `parser.py` 解析 DeepSeek `<|ref|>` 和 `<|det|>` 标签，并把归一化坐标缩放成图片像素坐标。它不负责解析百度云 JSON。
 - `redacter.py` 计算接近纸张背景的填充色，并在阶段之间涂抹区域。
@@ -26,9 +27,9 @@
 adapter.extract_page(prompt, image_path, output_path, size, context, device_number)
 ```
 
-adapter 返回 `OCRPageResult`，其中包含统一的 `Layout` 列表。DeepSeek adapter 可以先得到 DeepSeek-OCR 兼容标签字符串，再用 `parse_ocr_response()` 转换成布局；百度云 adapter 则直接把 `parse_result_url` JSON 映射成布局。
+adapter 返回 `OCRPageResult`，其中包含统一的 `Layout` 列表和可选 `StructuredPage`。DeepSeek adapter 可以先得到 DeepSeek-OCR 兼容标签字符串，再用 `parse_ocr_response()` 转换成布局；百度云 adapter 则直接把 `parse_result_url` JSON 映射成布局。两者都应在 adapter 或结构化层设置 `Layout.kind`。
 
-当 `stages > 1` 时，抽取器会在下一次模型调用前涂抹页面上方三分之二，以及识别到的下方文字块。这个行为应保留在 `extractor.py` 内；模型后端不应该感知阶段涂抹策略。
+当 `stages > 1` 时，抽取器会在下一次模型调用前涂抹页面上方三分之二，以及识别到的下方文字块。这个行为应保留在 `extractor.py` 内；模型后端不应该感知阶段涂抹策略。不支持多阶段的 adapter 可以暴露 `supports_multi_stage = False`，抽取器会 warning 并降为单阶段。
 
 ## 边界规则
 

--- a/references/local-development.md
+++ b/references/local-development.md
@@ -67,7 +67,9 @@ poetry run python scripts/ocr_sample.py --adapter baidu --image tests/images/fri
 poetry run python scripts/ocr_sample.py --adapter both --image tests/images/friendly-title.png
 ```
 
-该脚本默认读取 `tests/images/friendly-title.png`，分别调用 DeepSeek Vendor、百度云 OCR，或两者同时运行。成功输出会包含图片路径、layout 数量、前几个 layout 摘要、文本预览和耗时。可以用 `--image path/to/image.png` 指定其他图片。
+该脚本默认读取 `tests/images/friendly-title.png`，分别调用 DeepSeek Vendor、百度云 OCR，或两者同时运行。成功输出会包含图片路径、layout 数量、前几个 layout 的 `ref`、稳定 `kind`、供应商原始 `type`、文本预览和耗时。可以用 `--image path/to/image.png` 指定其他图片。
+
+新代码应优先依赖 `Layout.kind` 判断跨供应商稳定语义。`Layout.ref` 是兼容旧 DeepSeek 风格 API 的字段；`Layout.type` 和 `Layout.raw` 保留供应商原始数据，不应当作稳定跨供应商契约。需要结构化页面结果时，使用 `extract_page_results()` 读取 `OCRPageResult.structured`；只需要旧式扁平 layout 列表时，继续使用 `extract()`。
 
 ## 开发后端模式
 

--- a/scripts/ocr_sample.py
+++ b/scripts/ocr_sample.py
@@ -92,6 +92,7 @@ def _run_extractor(adapter_name: str, extractor, image_path: Path, size: str, li
             {
                 "index": index + 1,
                 "ref": layout.ref,
+                "kind": layout.kind.value,
                 "det": layout.det,
                 "type": layout.type,
                 "text": _preview_text(layout.text),
@@ -107,6 +108,7 @@ def _run_extractor(adapter_name: str, extractor, image_path: Path, size: str, li
 def _layout_summary(layout: Any) -> dict[str, Any]:
     return {
         "ref": layout.ref,
+        "kind": layout.kind.value,
         "det": layout.det,
         "type": layout.type,
         "text": _preview_text(layout.text),

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -2,6 +2,8 @@ import unittest
 
 from doc_page_extractor.adapters.baidu import parse_baidu_layouts
 from doc_page_extractor.adapters.deepseek import parse_deepseek_layouts
+from doc_page_extractor.structure import build_structured_page
+from doc_page_extractor.types import LayoutKind
 
 
 class _StubImage:
@@ -21,7 +23,26 @@ class TestAdapters(unittest.TestCase):
         self.assertEqual(layout.ref, "标题")
         self.assertEqual(layout.det, (100, 200, 300, 400))
         self.assertEqual(layout.text, "正文")
+        self.assertEqual(layout.kind, LayoutKind.UNKNOWN)
         self.assertEqual(layout.source, "deepseek-vendor")
+
+    def test_deepseek_known_refs_are_typed(self):
+        image = _StubImage(1000, 1000)
+        response = (
+            "<|ref|>image<|/ref|><|det|>[[100, 100, 800, 500]]<|/det|>"
+            "image-body"
+            "<|ref|>image_caption<|/ref|><|det|>[[100, 520, 800, 600]]<|/det|>"
+            "图一"
+        )
+
+        layouts = parse_deepseek_layouts(image, response)
+        structured = build_structured_page(layouts)
+
+        self.assertEqual(layouts[0].kind, LayoutKind.IMAGE)
+        self.assertEqual(layouts[1].kind, LayoutKind.IMAGE_CAPTION)
+        self.assertEqual(len(structured.blocks), 1)
+        self.assertEqual(structured.blocks[0].kind, LayoutKind.IMAGE)
+        self.assertEqual(structured.blocks[0].children[0].kind, LayoutKind.IMAGE_CAPTION)
 
     def test_baidu_layouts_from_json(self):
         parse_result = {
@@ -51,12 +72,60 @@ class TestAdapters(unittest.TestCase):
         layouts = parse_baidu_layouts(parse_result)
 
         self.assertEqual(len(layouts), 2)
-        self.assertEqual(layouts[0].ref, "paragraph_title")
+        self.assertEqual(layouts[0].ref, "sub_title")
         self.assertEqual(layouts[0].det, (161, 167, 518, 220))
         self.assertEqual(layouts[0].text, "第二章 鸿商巨贾")
+        self.assertEqual(layouts[0].kind, LayoutKind.TITLE)
         self.assertEqual(layouts[0].type, "paragraph_title")
         self.assertEqual(layouts[0].source, "baidu")
+        self.assertEqual(layouts[1].ref, "text")
+        self.assertEqual(layouts[1].kind, LayoutKind.TEXT)
         self.assertEqual(layouts[1].det, (158, 510, 1360, 1068))
+
+    def test_baidu_richer_types_collapse_to_stable_kinds(self):
+        parse_result = {
+            "pages": [
+                {
+                    "layouts": [
+                        {
+                            "text": "脚注内容",
+                            "position": [10, 900, 300, 40],
+                            "type": "footnote",
+                        },
+                        {
+                            "text": "第六表",
+                            "position": [100, 100, 100, 30],
+                            "type": "text",
+                        },
+                        {
+                            "text": "<table><tr><td>A</td></tr></table>",
+                            "position": [100, 140, 400, 200],
+                            "type": "table",
+                            "table_html": "<table><tr><td>A</td></tr></table>",
+                        },
+                        {
+                            "text": "1",
+                            "position": [500, 980, 10, 10],
+                            "type": "number",
+                        },
+                    ]
+                }
+            ]
+        }
+
+        layouts = parse_baidu_layouts(parse_result)
+        structured = build_structured_page(layouts)
+
+        self.assertEqual(layouts[0].kind, LayoutKind.FOOTNOTE)
+        self.assertEqual(layouts[0].ref, "text")
+        self.assertEqual(layouts[1].kind, LayoutKind.TABLE_CAPTION)
+        self.assertEqual(layouts[1].ref, "table_caption")
+        self.assertEqual(layouts[2].kind, LayoutKind.TABLE)
+        self.assertEqual(layouts[3].kind, LayoutKind.PAGE_NUMBER)
+        self.assertEqual(len(structured.ignored), 1)
+        self.assertEqual(structured.ignored[0].kind, LayoutKind.PAGE_NUMBER)
+        self.assertEqual(structured.blocks[1].kind, LayoutKind.TABLE)
+        self.assertEqual(structured.blocks[1].children[0].kind, LayoutKind.TABLE_CAPTION)
 
 
 if __name__ == "__main__":

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -44,6 +44,18 @@ class TestAdapters(unittest.TestCase):
         self.assertEqual(structured.blocks[0].kind, LayoutKind.IMAGE)
         self.assertEqual(structured.blocks[0].children[0].kind, LayoutKind.IMAGE_CAPTION)
 
+    def test_deepseek_zero_area_layouts_are_ignored(self):
+        image = _StubImage(1000, 1000)
+        response = (
+            "<|ref|>text<|/ref|><|det|>[[0, 0, 0, 0]]<|/det|>0"
+            "<|ref|>text<|/ref|><|det|>[[100, 100, 200, 200]]<|/det|>ok"
+        )
+
+        layouts = parse_deepseek_layouts(image, response)
+
+        self.assertEqual(len(layouts), 1)
+        self.assertEqual(layouts[0].text, "ok")
+
     def test_baidu_layouts_from_json(self):
         parse_result = {
             "file_name": "friendly-title.png",
@@ -93,6 +105,11 @@ class TestAdapters(unittest.TestCase):
                             "type": "footnote",
                         },
                         {
+                            "text": "正文",
+                            "position": [100, 300, 400, 100],
+                            "type": "text",
+                        },
+                        {
                             "text": "第 六 表",
                             "position": [100, 100, 100, 30],
                             "type": "text",
@@ -108,6 +125,16 @@ class TestAdapters(unittest.TestCase):
                             "position": [500, 980, 10, 10],
                             "type": "number",
                         },
+                        {
+                            "text": "① element",
+                            "position": [100, 1100, 120, 30],
+                            "type": "number",
+                        },
+                        {
+                            "text": "209",
+                            "position": [20, 320, 30, 30],
+                            "type": "text",
+                        },
                     ]
                 }
             ]
@@ -118,14 +145,20 @@ class TestAdapters(unittest.TestCase):
 
         self.assertEqual(layouts[0].kind, LayoutKind.FOOTNOTE)
         self.assertEqual(layouts[0].ref, "text")
-        self.assertEqual(layouts[1].kind, LayoutKind.TABLE_CAPTION)
-        self.assertEqual(layouts[1].ref, "table_caption")
-        self.assertEqual(layouts[2].kind, LayoutKind.TABLE)
-        self.assertEqual(layouts[3].kind, LayoutKind.PAGE_NUMBER)
-        self.assertEqual(len(structured.ignored), 1)
+        self.assertEqual(layouts[1].kind, LayoutKind.TEXT)
+        self.assertEqual(layouts[2].kind, LayoutKind.TABLE_CAPTION)
+        self.assertEqual(layouts[2].ref, "table_caption")
+        self.assertEqual(layouts[3].kind, LayoutKind.TABLE)
+        self.assertEqual(layouts[4].kind, LayoutKind.PAGE_NUMBER)
+        self.assertEqual(layouts[5].kind, LayoutKind.FOOTNOTE)
+        self.assertEqual(layouts[6].kind, LayoutKind.TEXT)
+        self.assertEqual(len(structured.ignored), 2)
         self.assertEqual(structured.ignored[0].kind, LayoutKind.PAGE_NUMBER)
-        self.assertEqual(structured.blocks[1].kind, LayoutKind.TABLE)
-        self.assertEqual(structured.blocks[1].children[0].kind, LayoutKind.TABLE_CAPTION)
+        self.assertEqual(structured.ignored[1].text, "209")
+        table_block = next(
+            block for block in structured.blocks if block.kind == LayoutKind.TABLE
+        )
+        self.assertEqual(table_block.children[0].kind, LayoutKind.TABLE_CAPTION)
 
 
 if __name__ == "__main__":

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -93,7 +93,7 @@ class TestAdapters(unittest.TestCase):
                             "type": "footnote",
                         },
                         {
-                            "text": "第六表",
+                            "text": "第 六 表",
                             "position": [100, 100, 100, 30],
                             "type": "text",
                         },

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -130,11 +130,6 @@ class TestAdapters(unittest.TestCase):
                             "position": [100, 1100, 120, 30],
                             "type": "number",
                         },
-                        {
-                            "text": "209",
-                            "position": [20, 320, 30, 30],
-                            "type": "text",
-                        },
                     ]
                 }
             ]
@@ -151,10 +146,8 @@ class TestAdapters(unittest.TestCase):
         self.assertEqual(layouts[3].kind, LayoutKind.TABLE)
         self.assertEqual(layouts[4].kind, LayoutKind.PAGE_NUMBER)
         self.assertEqual(layouts[5].kind, LayoutKind.FOOTNOTE)
-        self.assertEqual(layouts[6].kind, LayoutKind.TEXT)
-        self.assertEqual(len(structured.ignored), 2)
+        self.assertEqual(len(structured.ignored), 1)
         self.assertEqual(structured.ignored[0].kind, LayoutKind.PAGE_NUMBER)
-        self.assertEqual(structured.ignored[1].text, "209")
         table_block = next(
             block for block in structured.blocks if block.kind == LayoutKind.TABLE
         )

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -2,10 +2,16 @@ import unittest
 import warnings
 from pathlib import Path
 
-from PIL import Image
-
 from doc_page_extractor import ExtractionContext, Layout, OCRPageResult
 from doc_page_extractor.extractor import create_page_extractor_with_adapter
+
+
+class _FakeImage:
+    size = (100, 100)
+
+    def save(self, path: Path, image_format: str) -> None:
+        del image_format
+        path.write_bytes(b"fake")
 
 
 class _SingleStageAdapter:
@@ -40,7 +46,7 @@ class TestExtractor(unittest.TestCase):
             warnings.simplefilter("always")
             results = list(
                 extractor.extract(
-                    image=Image.new("RGB", (100, 100), "white"),
+                    image=_FakeImage(),  # type: ignore[arg-type]
                     size="tiny",
                     stages=2,
                     context=ExtractionContext(check_aborted=lambda: False),

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -37,6 +37,23 @@ class _SingleStageAdapter:
         )
 
 
+class _LegacyAdapter:
+    def extract_page(
+        self,
+        prompt: str,
+        image_path: Path,
+        output_path: Path,
+        size: str,
+        context: ExtractionContext | None,
+        device_number: int | None,
+    ) -> OCRPageResult:
+        del prompt, image_path, output_path, size, context, device_number
+        return OCRPageResult(
+            layouts=[Layout(ref="text", det=(0, 0, 10, 10), text="ok")],
+            source="legacy",
+        )
+
+
 class TestExtractor(unittest.TestCase):
     def test_single_stage_adapter_ignores_multi_stage_request(self):
         adapter = _SingleStageAdapter()
@@ -58,6 +75,25 @@ class TestExtractor(unittest.TestCase):
         self.assertEqual(results[0][1][0].text, "ok")
         self.assertEqual(len(caught), 1)
         self.assertEqual(caught[0].category, RuntimeWarning)
+
+    def test_legacy_adapter_gets_default_multi_stage_flag_and_structured_result(self):
+        adapter = _LegacyAdapter()
+        extractor = create_page_extractor_with_adapter(adapter)  # type: ignore[arg-type]
+
+        results = list(
+            extractor.extract_page_results(
+                image=_FakeImage(),  # type: ignore[arg-type]
+                size="tiny",
+                stages=1,
+                context=ExtractionContext(check_aborted=lambda: False),
+            )
+        )
+
+        self.assertTrue(adapter.supports_multi_stage)  # type: ignore[attr-defined]
+        structured = results[0][1].structured
+        self.assertIsNotNone(structured)
+        assert structured is not None
+        self.assertEqual(structured.blocks[0].text, "ok")
 
 
 if __name__ == "__main__":

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,58 @@
+import unittest
+import warnings
+from pathlib import Path
+
+from PIL import Image
+
+from doc_page_extractor import ExtractionContext, Layout, OCRPageResult
+from doc_page_extractor.extractor import create_page_extractor_with_adapter
+
+
+class _SingleStageAdapter:
+    supports_multi_stage = False
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def extract_page(
+        self,
+        prompt: str,
+        image_path: Path,
+        output_path: Path,
+        size: str,
+        context: ExtractionContext | None,
+        device_number: int | None,
+    ) -> OCRPageResult:
+        del prompt, image_path, output_path, size, context, device_number
+        self.calls += 1
+        return OCRPageResult(
+            layouts=[Layout(ref="text", det=(0, 0, 10, 10), text="ok")],
+            source="single-stage",
+        )
+
+
+class TestExtractor(unittest.TestCase):
+    def test_single_stage_adapter_ignores_multi_stage_request(self):
+        adapter = _SingleStageAdapter()
+        extractor = create_page_extractor_with_adapter(adapter)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            results = list(
+                extractor.extract(
+                    image=Image.new("RGB", (100, 100), "white"),
+                    size="tiny",
+                    stages=2,
+                    context=ExtractionContext(check_aborted=lambda: False),
+                )
+            )
+
+        self.assertEqual(adapter.calls, 1)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0][1][0].text, "ok")
+        self.assertEqual(len(caught), 1)
+        self.assertEqual(caught[0].category, RuntimeWarning)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- bump package version to 1.1.1
- add stable LayoutKind enum plus StructuredPage/PageBlock result model
- normalize DeepSeek and Baidu labels into stable layout kinds while keeping legacy ref/type fields
- add extract_page_results() for callers that need structured OCR output
- disable multi-stage redaction for Baidu with a warning, since Baidu extracts footnotes directly
- document the new API and architecture boundary
- keep normalization conservative: filter invalid zero-area DeepSeek boxes, classify Baidu number blocks that already look like footnotes as footnote, and classify table-title-like text such as spaced Chinese table captions as table_caption without changing OCR text

## Full sample audit
- Ran all 14 tests/images samples through DeepSeek Vendor and Baidu OCR.
- Generated bbox match reports and overlay images under /tmp/doc_page_extractor_full_check.
- A blind sub-agent audit also ran all samples and checked overlay output under /tmp/doc_page_extractor_blind_audit.
- No remaining large bbox/tag/text mismatch was found for ordinary non-rotated samples.
- Known residual: to-rotation.png is a model-quality/rotation case. DeepSeek Vendor may produce unstable output on that image; this PR filters zero-area boxes, but rotation-quality is not solved here.
- Known residual: Baidu may emit extra text-like marginal blocks, and DeepSeek may emit tiny empty image boxes. This PR leaves those model outputs visible instead of adding sample-specific cleanup.
- Known residual: Baidu can represent compound figures as multiple image boxes; future API work can use Baidu parent/children to expose sub-image hierarchy.

## Verification
- poetry run python test.py
- poetry run pylint --disable=import-error doc_page_extractor
- poetry run python build.py
- poetry run python scripts/ocr_sample.py --adapter both --image tests/images/friendly-title.png --limit 4
- poetry run python scripts/ocr_sample.py --adapter both --image tests/images/table.png --limit 8
- poetry run python /tmp/doc_page_extractor_full_check.py