### PR TITLE
Add manual PyPI release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,102 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11.14"
+
+      - name: Setup Poetry
+        uses: abatilo/actions-poetry@v3
+        with:
+          poetry-version: "2.1.3"
+
+      - name: Read version
+        id: version
+        run: |
+          VERSION="$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          print(data["project"]["version"])
+          PY
+          )"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Reject existing tag
+        run: |
+          if git rev-parse --verify --quiet "refs/tags/${{ steps.version.outputs.tag }}"; then
+            echo "Tag ${{ steps.version.outputs.tag }} already exists." >&2
+            exit 1
+          fi
+
+      - name: Verify package version
+        run: |
+          python - <<'PY'
+          import re
+          import tomllib
+          from pathlib import Path
+
+          pyproject_version = tomllib.loads(
+              Path("pyproject.toml").read_text(encoding="utf-8")
+          )["project"]["version"]
+          init_text = Path("doc_page_extractor/__init__.py").read_text(encoding="utf-8")
+          match = re.search(r'^__version__ = "([^"]+)"$', init_text, re.MULTILINE)
+          if match is None:
+              raise SystemExit("doc_page_extractor/__init__.py does not define __version__.")
+          package_version = match.group(1)
+          if package_version != pyproject_version:
+              raise SystemExit(
+                  f"Version mismatch: pyproject.toml={pyproject_version}, "
+                  f"__init__.py={package_version}"
+              )
+          PY
+
+      - name: Install dependencies
+        run: poetry install --only dev
+
+      - name: Run tests
+        run: poetry run python test.py
+
+      - name: Run lint
+        run: poetry run pylint --disable=import-error doc_page_extractor
+
+      - name: Build package
+        run: poetry build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --generate-notes

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,19 +1,38 @@
-# how to release
+# Release
 
-## 1. Configure PyPI token (first time only)
+Releases are published manually from GitHub Actions.
 
-```shell
-poetry config pypi-token.pypi $PYPI_TOKEN
-```
+## Prepare
 
-## 2. Build the package
+Update and commit the version in both places:
 
-```shell
-python build.py
-```
+- `pyproject.toml`
+- `doc_page_extractor/__init__.py`
 
-## 3. Publish to PyPI
+The release workflow reads `pyproject.toml` and publishes tag `vX.Y.Z`.
 
-```shell
-poetry publish
-```
+## Publish
+
+1. Open GitHub Actions.
+2. Select the `Release` workflow.
+3. Click `Run workflow` on `main`.
+
+The workflow will:
+
+1. Read `project.version` from `pyproject.toml`.
+2. Reject the release if tag `vX.Y.Z` already exists.
+3. Run tests and lint.
+4. Build the package.
+5. Publish to PyPI through Trusted Publishing.
+6. Push tag `vX.Y.Z`.
+7. Create a GitHub Release with generated notes.
+
+## PyPI Setup
+
+PyPI Trusted Publishing must match:
+
+- Repository: `Moskize91/doc-page-extractor`
+- Workflow: `release.yaml`
+- Environment: `pypi`
+
+No PyPI API token is required in GitHub Secrets.


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions Release workflow using workflow_dispatch
- read project.version from pyproject.toml and publish tag vX.Y.Z
- reject publishing when the tag already exists
- verify pyproject.toml and doc_page_extractor.__version__ match
- publish to PyPI via Trusted Publishing with environment pypi
- create the git tag and GitHub Release after PyPI publish
- update release documentation

## Setup required
PyPI Trusted Publishing must match:
- Repository: Moskize91/doc-page-extractor
- Workflow: release.yaml
- Environment: pypi

## Verification
- python version consistency check
- poetry run python test.py
- poetry run pylint --disable=import-error doc_page_extractor