### PR TITLE
Limit Baidu OCR upload image side

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ DOC_PAGE_EXTRACTOR_BAIDU_SK=
 DOC_PAGE_EXTRACTOR_BAIDU_BASE_URL=https://aip.baidubce.com
 ```
 
+Baidu images with a side longer than 8192 px are resized proportionally before
+upload. Returned layout coordinates are mapped back to the original image size.
+
 ## Extraction
 
 All backends return the same `PageExtractor` shape:

--- a/doc_page_extractor/__init__.py
+++ b/doc_page_extractor/__init__.py
@@ -1,6 +1,6 @@
 # pylint: disable=undefined-all-variable
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 _LAZY_EXPORTS = {
     "AbortError": ("extraction_context", "AbortError"),

--- a/doc_page_extractor/adapters/baidu.py
+++ b/doc_page_extractor/adapters/baidu.py
@@ -60,6 +60,7 @@ class BaiduCloudOCRConfig:
 
 class BaiduCloudOCRAdapter:
     supports_multi_stage = False
+    max_image_side = 8192
 
     def __init__(self, config: BaiduCloudOCRConfig) -> None:
         self._config = config

--- a/doc_page_extractor/extractor.py
+++ b/doc_page_extractor/extractor.py
@@ -130,19 +130,31 @@ class _PageExtractorImpls:
             for i in range(stages):
                 image_path = output_path / f"raw-{i+1}.png"
                 image.save(image_path, "PNG")
+                prepared_image_path, scale_x, scale_y = _prepare_adapter_image(
+                    image=image,
+                    image_path=image_path,
+                    output_path=output_path,
+                    max_image_side=getattr(self._adapter, "max_image_side", None),
+                )
                 try:
                     page_result = self._adapter.extract_page(
                         prompt=_DEFAULT_PROMPT,
-                        image_path=image_path,
+                        image_path=prepared_image_path,
                         output_path=output_path,
                         size=size,
                         context=context,
                         device_number=device_number,
                     )
                 finally:
+                    if prepared_image_path != image_path:
+                        prepared_image_path.unlink(missing_ok=True)
                     image_path.unlink(missing_ok=True)
 
                 layouts = page_result.layouts
+                if scale_x != 1.0 or scale_y != 1.0:
+                    _scale_layout_coordinates(layouts, scale_x, scale_y)
+                    if page_result.structured is not None:
+                        page_result.structured = build_structured_page(layouts)
                 if page_result.structured is None:
                     page_result.structured = build_structured_page(layouts)
                 yield image, page_result
@@ -198,3 +210,44 @@ class _PageExtractorImpls:
             if left < right:
                 yield (left, y_cutted, right, y_cutted + height)
                 forbidden = right
+
+
+def _prepare_adapter_image(
+    image: "Image.Image",
+    image_path: Path,
+    output_path: Path,
+    max_image_side: int | None,
+) -> tuple[Path, float, float]:
+    if max_image_side is None:
+        return image_path, 1.0, 1.0
+
+    width, height = image.size
+    max_side = max(width, height)
+    if max_side <= max_image_side:
+        return image_path, 1.0, 1.0
+
+    ratio = max_image_side / max_side
+    resized_width = max(1, round(width * ratio))
+    resized_height = max(1, round(height * ratio))
+    resized_path = output_path / f"{image_path.stem}-resized.png"
+    resized = image.resize((resized_width, resized_height))
+    resized.save(resized_path, "PNG")
+
+    return resized_path, width / resized_width, height / resized_height
+
+
+def _scale_layout_coordinates(
+    layouts: list[Layout], scale_x: float, scale_y: float
+) -> None:
+    for layout in layouts:
+        x1, y1, x2, y2 = layout.det
+        layout.det = (
+            round(x1 * scale_x),
+            round(y1 * scale_y),
+            round(x2 * scale_x),
+            round(y2 * scale_y),
+        )
+        if layout.polygon is not None:
+            layout.polygon = [
+                (round(x * scale_x), round(y * scale_y)) for x, y in layout.polygon
+            ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "doc-page-extractor"
-version = "1.1.1"
+version = "1.1.2"
 description = "Document page extraction tool with DeepSeek-OCR and Baidu OCR adapters"
 authors = [
     {name = "Tao Zeyu", email = "i@taozeyu.com"}

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -14,6 +14,27 @@ class _FakeImage:
         path.write_bytes(b"fake")
 
 
+class _FakeResizedImage:
+    def __init__(self, size: tuple[int, int]) -> None:
+        self.size = size
+        self.saved_paths: list[Path] = []
+
+    def save(self, path: Path, image_format: str) -> None:
+        del image_format
+        self.saved_paths.append(path)
+        path.write_bytes(b"resized")
+
+
+class _FakeResizableImage(_FakeResizedImage):
+    def __init__(self) -> None:
+        super().__init__((9000, 4500))
+        self.resize_size: tuple[int, int] | None = None
+
+    def resize(self, size: tuple[int, int]) -> _FakeResizedImage:
+        self.resize_size = size
+        return _FakeResizedImage(size)
+
+
 class _SingleStageAdapter:
     supports_multi_stage = False
 
@@ -51,6 +72,42 @@ class _LegacyAdapter:
         return OCRPageResult(
             layouts=[Layout(ref="text", det=(0, 0, 10, 10), text="ok")],
             source="legacy",
+        )
+
+
+class _MaxSideAdapter:
+    supports_multi_stage = True
+    max_image_side = 8192
+
+    def __init__(self) -> None:
+        self.image_path: Path | None = None
+
+    def extract_page(
+        self,
+        prompt: str,
+        image_path: Path,
+        output_path: Path,
+        size: str,
+        context: ExtractionContext | None,
+        device_number: int | None,
+    ) -> OCRPageResult:
+        del prompt, output_path, size, context, device_number
+        self.image_path = image_path
+        return OCRPageResult(
+            layouts=[
+                Layout(
+                    ref="text",
+                    det=(100, 200, 400, 600),
+                    text="ok",
+                    polygon=[
+                        (100, 200),
+                        (400, 200),
+                        (400, 600),
+                        (100, 600),
+                    ],
+                )
+            ],
+            source="max-side",
         )
 
 
@@ -94,6 +151,31 @@ class TestExtractor(unittest.TestCase):
         self.assertIsNotNone(structured)
         assert structured is not None
         self.assertEqual(structured.blocks[0].text, "ok")
+
+    def test_adapter_max_image_side_resizes_upload_and_maps_coordinates(self):
+        adapter = _MaxSideAdapter()
+        image = _FakeResizableImage()
+        extractor = create_page_extractor_with_adapter(adapter)
+
+        results = list(
+            extractor.extract_page_results(
+                image=image,  # type: ignore[arg-type]
+                size="tiny",
+                stages=1,
+                context=ExtractionContext(check_aborted=lambda: False),
+            )
+        )
+
+        self.assertEqual(image.resize_size, (8192, 4096))
+        self.assertIsNotNone(adapter.image_path)
+        assert adapter.image_path is not None
+        self.assertEqual(adapter.image_path.name, "raw-1-resized.png")
+        layout = results[0][1].layouts[0]
+        self.assertEqual(layout.det, (110, 220, 439, 659))
+        self.assertEqual(
+            layout.polygon,
+            [(110, 220), (439, 220), (439, 659), (110, 659)],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add adapter-driven max image side normalization before OCR calls.
- Set Baidu Cloud OCR adapter max image side to 8192 px.
- Map normalized layout coordinates and polygons back to the original image size.
- Bump package version to 1.1.2 and document the Baidu behavior.

## Notes
- Only adapters that declare an internal max_image_side are resized; DeepSeek local and Vendor paths are unchanged.
- Short-side inputs are not blocked locally; provider errors pass through as before.

## Verification
- poetry run python test.py
- poetry run pylint --disable=import-error doc_page_extractor