### PR TITLE
Fix local DeepSeek OCR2 parser selection

### DIFF
--- a/doc_page_extractor/adapters/deepseek.py
+++ b/doc_page_extractor/adapters/deepseek.py
@@ -3,7 +3,7 @@ import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generator, Protocol, cast
+from typing import TYPE_CHECKING, Any, Callable, Generator, Protocol, cast
 
 from ..parser import ParsedItemKind, parse_ocr_response
 from ..structure import build_structured_page, deepseek_ref_to_kind
@@ -22,6 +22,9 @@ if TYPE_CHECKING:
 
 class _ImageLike(Protocol):
     size: tuple[int, int]
+
+
+DeepSeekLayoutParser = Callable[[_ImageLike, str, str], list[Layout]]
 
 
 def parse_deepseek_ocr_layouts(
@@ -64,9 +67,15 @@ def _deepseek_layout(
 class DeepSeekModelOCRAdapter:
     supports_multi_stage = True
 
-    def __init__(self, model: OCRModel, source: str = "deepseek-ocr") -> None:
+    def __init__(
+        self,
+        model: OCRModel,
+        source: str = "deepseek-ocr",
+        parse_layouts: DeepSeekLayoutParser = parse_deepseek_ocr_layouts,
+    ) -> None:
         self._model = model
         self._source = source
+        self._parse_layouts = parse_layouts
 
     def download(self, revision: str | None) -> None:
         self._model.download(revision)
@@ -94,7 +103,7 @@ class DeepSeekModelOCRAdapter:
         from PIL import Image
 
         with Image.open(image_path) as image:
-            layouts = parse_deepseek_ocr_layouts(image, response, source=self._source)
+            layouts = self._parse_layouts(image, response, self._source)
         return OCRPageResult(
             layouts=layouts,
             source=self._source,

--- a/doc_page_extractor/extractor.py
+++ b/doc_page_extractor/extractor.py
@@ -11,6 +11,8 @@ from .adapters.deepseek import (
     DeepSeekModelOCRAdapter,
     DeepSeekOCRVendorAdapter,
     DeepSeekOCRVendorConfig,
+    parse_deepseek_ocr2_layouts,
+    parse_deepseek_ocr_layouts,
 )
 from .types import (
     DeepSeekOCRSize,
@@ -43,6 +45,7 @@ def create_ocr_page_extractor(
             local_only=local_only,
             enable_devices_numbers=enable_devices_numbers,
         )
+        parse_layouts = parse_deepseek_ocr_layouts
     elif ocr_model == "deepseek-ocr2":
         from .model import DeepSeekOCR2HuggingFaceModel
 
@@ -51,10 +54,17 @@ def create_ocr_page_extractor(
             local_only=local_only,
             enable_devices_numbers=enable_devices_numbers,
         )
+        parse_layouts = parse_deepseek_ocr2_layouts
     else:
         raise ValueError(f"Unsupported OCR model: {ocr_model}")
 
-    return _PageExtractorImpls(DeepSeekModelOCRAdapter(model, source=ocr_model))
+    return _PageExtractorImpls(
+        DeepSeekModelOCRAdapter(
+            model,
+            source=ocr_model,
+            parse_layouts=parse_layouts,
+        )
+    )
 
 
 def create_page_extractor_with_adapter(adapter: OCRAdapter) -> PageExtractor:

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -3,6 +3,7 @@ import types
 import unittest
 import warnings
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from doc_page_extractor import ExtractionContext, Layout, OCRPageResult
@@ -17,6 +18,16 @@ class _FakeImage:
     def save(self, path: Path, image_format: str) -> None:
         del image_format
         path.write_bytes(b"fake")
+
+
+class _FakeOpenedImage:
+    size = (100, 100)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        del exc_type, exc_value, traceback
 
 
 class _FakeResizedImage:
@@ -199,20 +210,55 @@ class TestExtractor(unittest.TestCase):
 
             def generate(self, *args, **kwargs) -> str:
                 del args, kwargs
-                return "<|ref|>text<|/ref|><|det|>[[1, 1, 10, 10]]<|/det|>ok"
+                return (
+                    "<|ref|>text<|/ref|>"
+                    "<|det|>[[100, 100, 500, 200]]<|/det|>ocr1 text"
+                )
 
         class _DeepSeek2Model(_DeepSeek1Model):
-            pass
+            def generate(self, *args, **kwargs) -> str:
+                del args, kwargs
+                return "text[[100, 100, 500, 200]]\nocr2 text"
 
         fake_model_module = types.ModuleType("doc_page_extractor.model")
         fake_model_module.DeepSeekOCRHuggingFaceModel = _DeepSeek1Model
         fake_model_module.DeepSeekOCR2HuggingFaceModel = _DeepSeek2Model
-        with patch.dict(sys.modules, {"doc_page_extractor.model": fake_model_module}):
+        fake_pil_module = types.ModuleType("PIL")
+        fake_pil_module.Image = SimpleNamespace(open=lambda _path: _FakeOpenedImage())
+        with patch.dict(
+            sys.modules,
+            {
+                "doc_page_extractor.model": fake_model_module,
+                "PIL": fake_pil_module,
+            },
+        ):
             extractor1 = create_ocr_page_extractor("deepseek-ocr", model_path="models-cache")
             extractor2 = create_ocr_page_extractor("deepseek-ocr2", model_path="models-cache")
 
-        self.assertIsInstance(extractor1._adapter._model, _DeepSeek1Model)  # type: ignore[attr-defined]
-        self.assertIsInstance(extractor2._adapter._model, _DeepSeek2Model)  # type: ignore[attr-defined]
+            self.assertIsInstance(extractor1._adapter._model, _DeepSeek1Model)  # type: ignore[attr-defined]
+            self.assertIsInstance(extractor2._adapter._model, _DeepSeek2Model)  # type: ignore[attr-defined]
+
+            result1 = list(
+                extractor1.extract_page_results(
+                    image=_FakeImage(),  # type: ignore[arg-type]
+                    size="tiny",
+                    stages=1,
+                    context=ExtractionContext(check_aborted=lambda: False),
+                )
+            )[0][1]
+            result2 = list(
+                extractor2.extract_page_results(
+                    image=_FakeImage(),  # type: ignore[arg-type]
+                    size="tiny",
+                    stages=1,
+                    context=ExtractionContext(check_aborted=lambda: False),
+                )
+            )[0][1]
+
+        self.assertEqual(result1.layouts[0].text, "ocr1 text")
+        self.assertEqual(result1.layouts[0].det, (10, 10, 50, 20))
+        self.assertEqual(result2.layouts[0].text, "ocr2 text")
+        self.assertEqual(result2.layouts[0].det, (10, 10, 50, 20))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Inject the DeepSeek layout parser into the local model adapter.
- Select the OCR1 parser for local `deepseek-ocr` and the OCR2 line-block parser for local `deepseek-ocr2`.
- Add fake-model unit coverage for local OCR1/OCR2 extraction without CUDA, network, or model downloads.

## Verification

- `poetry run python test.py`
- `poetry run pylint --disable=import-error doc_page_extractor`
