### PR TITLE
Document OCR sample modes and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ poetry run pylint --disable=import-error doc_page_extractor
 poetry run python scripts/ocr_sample.py --adapter unlimited-ocr-vendor --image tests/images/friendly-title.png
 ```
 
+`scripts/ocr_sample.py` also supports `deepseek-ocr-local`, `deepseek-ocr2-local`, `unlimited-ocr-local`, and `all`; `all` includes the local CUDA-backed modes.
+
 ## Requirements
 
 - Python >= 3.10, < 3.14

--- a/doc_page_extractor/__init__.py
+++ b/doc_page_extractor/__init__.py
@@ -1,6 +1,6 @@
 # pylint: disable=undefined-all-variable
 
-__version__ = "1.1.2"
+__version__ = "1.2.0"
 
 _LAZY_EXPORTS = {
     "AbortError": ("extraction_context", "AbortError"),

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -128,9 +128,13 @@ After filling private settings in `.env`, run:
 poetry run python scripts/ocr_sample.py --adapter deepseek-ocr-vendor --image tests/images/friendly-title.png
 poetry run python scripts/ocr_sample.py --adapter deepseek-ocr2-vendor --image tests/images/friendly-title.png
 poetry run python scripts/ocr_sample.py --adapter unlimited-ocr-vendor --image tests/images/friendly-title.png
+poetry run python scripts/ocr_sample.py --adapter deepseek-ocr-local --image tests/images/friendly-title.png
+poetry run python scripts/ocr_sample.py --adapter deepseek-ocr2-local --image tests/images/friendly-title.png
+poetry run python scripts/ocr_sample.py --adapter unlimited-ocr-local --image tests/images/friendly-title.png
 ```
 
 The sample reads `tests/images/friendly-title.png`, runs the configured OCR adapter, and prints layout summaries, including `kind`, provider `type`, text previews, and elapsed time. Use `--image path/to/image.png` to try another image.
+`--adapter all` runs all six backends in one pass, so it includes the local CUDA paths as well as the vendor paths.
 
 ### Build Package
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "doc-page-extractor"
-version = "1.1.2"
+version = "1.2.0"
 description = "Document page extraction tool with local and vendor OCR backends"
 authors = [
     {name = "Tao Zeyu", email = "i@taozeyu.com"}

--- a/references/local-development.md
+++ b/references/local-development.md
@@ -73,9 +73,13 @@ poetry run pylint --disable=import-error doc_page_extractor
 poetry run python scripts/ocr_sample.py --adapter deepseek-ocr-vendor --image tests/images/friendly-title.png
 poetry run python scripts/ocr_sample.py --adapter deepseek-ocr2-vendor --image tests/images/friendly-title.png
 poetry run python scripts/ocr_sample.py --adapter unlimited-ocr-vendor --image tests/images/friendly-title.png
+poetry run python scripts/ocr_sample.py --adapter deepseek-ocr-local --image tests/images/friendly-title.png
+poetry run python scripts/ocr_sample.py --adapter deepseek-ocr2-local --image tests/images/friendly-title.png
+poetry run python scripts/ocr_sample.py --adapter unlimited-ocr-local --image tests/images/friendly-title.png
 ```
 
 该脚本默认读取 `tests/images/friendly-title.png`，调用指定 OCR adapter。成功输出会包含图片路径、layout 数量、前几个 layout 的稳定 `kind`、供应商原始 `type`、文本预览和耗时。可以用 `--image path/to/image.png` 指定其他图片。
+`--adapter all` 会同时跑六个后端，其中包含本地 CUDA 路径，只适合 CUDA/NVIDIA 环境。
 
 新代码应依赖 `Layout.kind` 判断跨供应商稳定语义。`Layout.type` 和 `Layout.raw` 保留供应商原始数据，不应当作稳定跨供应商契约。使用 `extract_page_results()` 读取 `OCRPageResult` 和可选的 `structured` 页面结构。
 


### PR DESCRIPTION
## Summary
- bump package version to 1.2.0
- document all six OCR sample adapter modes
- clarify that `--adapter all` includes local CUDA-backed modes

## Tests
- python -m unittest tests.test_import_boundaries tests.test_extractor -v